### PR TITLE
fix: support Minecraft 26.2 (Adventure 5) click events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,12 @@ allprojects {
         maven { url 'https://mvn-repo.arim.space/lesser-gpl3/' }
     }
 
+    configurations.configureEach {
+        // MineDown is vendored (see common/src/main/java/de/themoep/minedown/adventure) with support for the
+        // Adventure 5 click event API used by Minecraft 26.2; don't let a transitive copy of it shadow that.
+        exclude group: 'net.william278', module: 'minedown'
+    }
+
     dependencies {
         testImplementation(platform("org.junit:junit-bom:5.13.4"))
         testImplementation 'org.junit.jupiter:junit-jupiter'
@@ -97,6 +103,8 @@ allprojects {
     license {
         rule(rootProject.file('HEADER'))
         include('**/*.java')
+        // Vendored MineDown (MIT licensed) - see common/src/main/java/de/themoep/minedown/adventure
+        exclude('**/de/themoep/minedown/**')
     }
 
     test {

--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     implementation project(path: ':common')
 
-    implementation 'net.kyori:adventure-platform-bukkit:4.4.0'
+    implementation 'net.kyori:adventure-platform-bukkit:4.4.1'
     implementation 'io.papermc:paperlib:1.0.8'
     implementation 'space.arim.morepaperlib:morepaperlib:0.4.4'
     implementation 'net.william278.cloplib:cloplib-bukkit:2.0.12'

--- a/bukkit/src/main/java/net/william278/huskclaims/BukkitHuskClaims.java
+++ b/bukkit/src/main/java/net/william278/huskclaims/BukkitHuskClaims.java
@@ -27,6 +27,7 @@ import com.google.gson.Gson;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.platform.AudienceProvider;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import net.william278.cloplib.operation.OperationType;
@@ -64,6 +65,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.messaging.PluginMessageListener;
@@ -83,7 +85,16 @@ public class BukkitHuskClaims extends JavaPlugin implements HuskClaims, BukkitTa
         BukkitBlockProvider, BukkitSafeTeleportProvider, BukkitPetHandler, BukkitEventDispatcher, BukkitHookProvider,
         PluginMessageListener {
 
+    /**
+     * Whether the server implements Adventure natively (Paper 1.16.5+), in which case {@link CommandSender}s are
+     * {@link Audience}s themselves and the legacy adventure-platform bridge isn't needed - which matters on
+     * Minecraft 26.2, where the server ships Adventure 5 and adventure-platform (built for Adventure 4) can't be
+     * used to send components.
+     */
+    private static final boolean NATIVE_AUDIENCES = Audience.class.isAssignableFrom(CommandSender.class);
+
     private MorePaperLib morePaperLib;
+    @Nullable
     private AudienceProvider audiences;
     private Toilet toilet;
     private final Gson gson = getGsonBuilder().create();
@@ -128,7 +139,7 @@ public class BukkitHuskClaims extends JavaPlugin implements HuskClaims, BukkitTa
 
     @Override
     public void onEnable() {
-        this.audiences = BukkitAudiences.create(this);
+        this.audiences = NATIVE_AUDIENCES ? null : BukkitAudiences.create(this);
         this.morePaperLib = new MorePaperLib(this);
         this.toilet = BukkitToilet.create(getDumpOptions());
         this.enable();
@@ -253,10 +264,38 @@ public class BukkitHuskClaims extends JavaPlugin implements HuskClaims, BukkitTa
         });
     }
 
+    @NotNull
+    @Override
+    public Audience getAudience(@NotNull UUID user) {
+        if (!NATIVE_AUDIENCES) {
+            return getAudiences().player(user);
+        }
+        final Player player = getServer().getPlayer(user);
+        return player == null || !player.isOnline() ? Audience.empty() : (Audience) player;
+    }
+
     @Override
     @NotNull
     public ConsoleUser getConsole() {
-        return ConsoleUser.wrap(audiences.console());
+        return ConsoleUser.wrap(NATIVE_AUDIENCES
+                ? (Audience) getServer().getConsoleSender() : getAudiences().console());
+    }
+
+    /**
+     * Get the legacy adventure-platform audience provider, creating it if needed.
+     * <p>
+     * Prefer {@link #getAudience(UUID)} and {@link #getConsole()}; on servers that support Adventure natively this
+     * bridge is never used as it doesn't support the Adventure version modern servers ship with.
+     *
+     * @return the {@link AudienceProvider}
+     */
+    @NotNull
+    @Override
+    public synchronized AudienceProvider getAudiences() {
+        if (audiences == null) {
+            audiences = BukkitAudiences.create(this);
+        }
+        return audiences;
     }
 
     @Override

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -9,7 +9,6 @@ dependencies {
     api 'org.apache.commons:commons-text:1.13.1'
     api 'com.google.code.gson:gson:2.13.1'
     api 'com.fatboyindustrial.gson-javatime-serialisers:gson-javatime-serialisers:1.1.2'
-    api 'net.william278:minedown:1.8.2'
     api 'net.william278:paginedown:1.1.2'
     api 'net.william278.cloplib:cloplib-common:2.0.12'
     api 'net.william278:DesertWell:2.0.4'
@@ -19,8 +18,9 @@ dependencies {
 
     compileOnly 'de.exlll:configlib-yaml:4.6.1'
     compileOnly 'it.unimi.dsi:fastutil:8.5.16'
-    compileOnly 'net.kyori:adventure-api:4.24.0'
-    compileOnly 'net.kyori:adventure-platform-api:4.4.0'
+    compileOnly 'net.kyori:adventure-api:5.2.0'
+    compileOnly 'net.kyori:adventure-text-serializer-legacy:5.2.0'
+    compileOnly 'net.kyori:adventure-platform-api:4.4.1'
     compileOnly 'org.jetbrains:annotations:26.0.2'
     compileOnly 'com.google.guava:guava:33.4.8-jre'
     compileOnly 'org.projectlombok:lombok:1.18.38'
@@ -38,6 +38,8 @@ dependencies {
         exclude group: 'com.google.code.gson'
     }
 
+    testImplementation 'net.kyori:adventure-api:5.2.0'
+    testImplementation 'net.kyori:adventure-text-serializer-legacy:5.2.0'
     testImplementation 'com.github.plan-player-analytics:Plan:5.6.2965'
     testImplementation 'com.google.guava:guava:33.4.8-jre'
     testImplementation 'it.unimi.dsi:fastutil:8.5.16'

--- a/common/src/main/java/de/themoep/minedown/adventure/AdventureCompat.java
+++ b/common/src/main/java/de/themoep/minedown/adventure/AdventureCompat.java
@@ -1,0 +1,203 @@
+package de.themoep.minedown.adventure;
+
+/*
+ * Copyright (c) 2020 Max Lee (https://github.com/Phoenix616)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentBuilder;
+import net.kyori.adventure.text.format.ShadowColor;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextFormat;
+import net.kyori.adventure.text.object.ObjectContents;
+import net.kyori.adventure.text.object.PlayerHeadObjectContents;
+
+import java.util.UUID;
+
+/**
+ * Holds every call into parts of the Adventure API that only exist on newer versions of it.
+ * <p>
+ * HuskClaims runs on Minecraft 1.17 all the way up to 26.2, which means the Adventure version provided by the
+ * server (or bundled by the adventure platform on legacy servers) can be anything from 4.9 to 5.x. Keeping these
+ * calls out of {@link MineDownParser} means the parser never resolves classes the running Adventure version
+ * doesn't have; this class is only ever loaded when a message actually uses one of the newer features.
+ *
+ * @see Util#createClickEvent(net.kyori.adventure.text.event.ClickEvent.Action, String, net.kyori.adventure.nbt.api.BinaryTagHolder)
+ */
+final class AdventureCompat {
+
+    /**
+     * Whether the running Adventure version supports shadow colors (Adventure 4.18+, Minecraft 1.21.4+)
+     */
+    static final boolean SHADOW_SUPPORTED = Util.hasClass("net.kyori.adventure.text.format.ShadowColor");
+
+    /**
+     * Whether the running Adventure version supports object components - player heads, sprites and atlases
+     * (Adventure 4.25+ / 5.x, Minecraft 1.21.9+)
+     */
+    static final boolean OBJECTS_SUPPORTED = Util.hasClass("net.kyori.adventure.text.object.ObjectContents");
+
+    private AdventureCompat() {
+    }
+
+    /**
+     * Create a shadow color from a text color
+     *
+     * @param color The color to base the shadow on
+     * @param alpha The alpha value of the shadow
+     * @return The shadow color, or <code>null</code> if this Adventure version has no shadow color support
+     */
+    static Object shadowColor(TextFormat color, int alpha) {
+        if (!SHADOW_SUPPORTED) {
+            return null;
+        }
+        return ShadowColor.shadowColor((TextColor) color, alpha);
+    }
+
+    /**
+     * Parse a shadow color from a hex string
+     *
+     * @param hexString The hex string to parse
+     * @return The shadow color, or <code>null</code> if it could not be parsed or isn't supported
+     */
+    static Object shadowFromHexString(String hexString) {
+        if (!SHADOW_SUPPORTED) {
+            return null;
+        }
+        return ShadowColor.fromHexString(hexString);
+    }
+
+    /**
+     * Apply a shadow color to a component builder
+     *
+     * @param builder The builder to apply the shadow to
+     * @param shadow  The shadow color, as returned by one of the methods in this class
+     */
+    static void applyShadow(ComponentBuilder<?, ?> builder, Object shadow) {
+        if (!SHADOW_SUPPORTED || !(shadow instanceof ShadowColor)) {
+            return;
+        }
+        builder.shadowColor((ShadowColor) shadow);
+    }
+
+    /**
+     * Create a new player head object contents builder
+     *
+     * @return The builder
+     * @throws IllegalArgumentException If this Adventure version has no object component support
+     */
+    static Object playerHead() {
+        requireObjects("player_head");
+        return ObjectContents.playerHead();
+    }
+
+    /**
+     * Set the player uuid of a player head
+     *
+     * @param playerHead The player head builder
+     * @param id         The uuid of the player
+     */
+    static void playerHeadId(Object playerHead, UUID id) {
+        ((PlayerHeadObjectContents.Builder) playerHead).id(id);
+    }
+
+    /**
+     * Set the texture key of a player head
+     *
+     * @param playerHead The player head builder
+     * @param texture    The texture key
+     */
+    static void playerHeadTexture(Object playerHead, Key texture) {
+        ((PlayerHeadObjectContents.Builder) playerHead).texture(texture);
+    }
+
+    /**
+     * Set the player name of a player head
+     *
+     * @param playerHead The player head builder
+     * @param name       The name of the player
+     */
+    static void playerHeadName(Object playerHead, String name) {
+        ((PlayerHeadObjectContents.Builder) playerHead).name(name);
+    }
+
+    /**
+     * Set whether a player head should be rendered with its hat layer
+     *
+     * @param playerHead The player head builder
+     * @param hat        Whether to render the hat layer
+     */
+    static void playerHeadHat(Object playerHead, boolean hat) {
+        ((PlayerHeadObjectContents.Builder) playerHead).hat(hat);
+    }
+
+    /**
+     * Add a profile property to a player head
+     *
+     * @param playerHead The player head builder
+     * @param name       The name of the property
+     * @param value      The value of the property
+     * @param signature  The signature of the property, may be null
+     */
+    static void playerHeadProperty(Object playerHead, String name, String value, String signature) {
+        final PlayerHeadObjectContents.Builder builder = (PlayerHeadObjectContents.Builder) playerHead;
+        builder.profileProperty(signature != null
+                ? PlayerHeadObjectContents.property(name, value, signature)
+                : PlayerHeadObjectContents.property(name, value));
+    }
+
+    /**
+     * Build a player head object component
+     *
+     * @param playerHead The player head builder
+     * @return The built component
+     */
+    static Component playerHeadComponent(Object playerHead) {
+        requireObjects("player_head");
+        return Component.object(((PlayerHeadObjectContents.Builder) playerHead).build());
+    }
+
+    /**
+     * Build a sprite object component
+     *
+     * @param atlas  The atlas the sprite is from, may be null
+     * @param sprite The sprite key
+     * @return The built component
+     */
+    static Component spriteComponent(Key atlas, Key sprite) {
+        requireObjects("sprite");
+        if (atlas != null) {
+            return Component.object(ObjectContents.sprite(atlas, sprite));
+        }
+        if (sprite.value().startsWith("item/")) {
+            return Component.object(ObjectContents.sprite(Key.key(sprite.namespace(), "items"), sprite));
+        }
+        return Component.object(ObjectContents.sprite(sprite));
+    }
+
+    private static void requireObjects(String feature) {
+        if (!OBJECTS_SUPPORTED) {
+            throw new IllegalArgumentException(feature + " requires Adventure 4.25 or newer (Minecraft 1.21.9+)!");
+        }
+    }
+
+}

--- a/common/src/main/java/de/themoep/minedown/adventure/MineDown.java
+++ b/common/src/main/java/de/themoep/minedown/adventure/MineDown.java
@@ -1,0 +1,452 @@
+package de.themoep.minedown.adventure;
+
+/*
+ * Copyright (c) 2020 Max Lee (https://github.com/Phoenix616)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
+
+import java.util.Map;
+
+/**
+ * <h2>MineDown-adventure</h2>
+ * A MarkDown inspired markup for Minecraft chat components using the adventure component library.
+ * <p>
+ * This lets you convert string messages into chat components by using a custom mark up syntax
+ * which is loosely based on MarkDown while still supporting legacy formatting codes.
+ */
+public class MineDown {
+    static final String FONT_PREFIX = "font=";
+    static final String COLOR_PREFIX = "color=";
+    static final String SHADOW_PREFIX = "shadow=";
+    static final String FORMAT_PREFIX = "format=";
+    static final String TRANSLATE_PREFIX = "translate=";
+    static final String WITH_PREFIX = "with=";
+    static final String PLAYER_HEAD_PREFIX = "player_head=";
+    static final String HAT_PREFIX = "hat=";
+    static final String TEXTURE_PREFIX = "texture=";
+    static final String PROFILE_PREFIX = "profile=";
+    static final String SPRITE_PREFIX = "sprite=";
+    static final String ATLAS_PREFIX = "atlas=";
+    static final String PAYLOAD_PREFIX = "payload=";
+    static final String HOVER_PREFIX = "hover=";
+    static final String INSERTION_PREFIX = "insert=";
+
+    static final int SHADOW_ALPHA = 100;
+
+    private String message;
+    private final Replacer replacer = new Replacer();
+    private final MineDownParser parser = new MineDownParser();
+    private Component components = null;
+    private boolean replaceFirst = Boolean.getBoolean("de.themoep.minedown.adventure.replacefirst");
+    
+    /**
+     * Create a new MineDown builder with a certain message
+     * @param message The message to parse
+     */
+    public MineDown(String message) {
+        this.message = message;
+    }
+    
+    /**
+     * Parse a MineDown string to components
+     * @param message       The message to translate
+     * @param replacements  Optional placeholder replacements
+     * @return              The parsed components
+     */
+    public static Component parse(String message, String... replacements) {
+        return new MineDown(message).replace(replacements).toComponent();
+    }
+    
+    /**
+     * Parse and convert the message to the component
+     * @return The parsed component message
+     */
+    public Component toComponent() {
+        if (components() == null) {
+            String message = message();
+            if (replaceFirst()) {
+                message = replacer().replaceStrings(message);
+            }
+            components = replacer().replaceIn(parser().parse(message).build().compact());
+        }
+        return components();
+    }
+    
+    /**
+     * Remove a cached component and re-parse the next time {@link #toComponent} is called
+     */
+    private void reset() {
+        components = null;
+    }
+
+    /**
+     * Set whether or not replacements should be replaced before or after the components are created.
+     * When replacing first it will not replace any placeholders with component replacement values!
+     * Default is after. (replaceFirst = false)
+     * @param replaceFirst  Whether or not to replace first or parse first
+     * @return              The MineDown instance
+     */
+    public MineDown replaceFirst(boolean replaceFirst) {
+        reset();
+        this.replaceFirst = replaceFirst;
+        return this;
+    }
+
+    /**
+     * Get whether or not replacements should be replaced before or after the components are created.
+     * When replacing first it will not replace any placeholders with component replacement values!
+     * Default is after. (replaceFirst = false)
+     * @return Whether or not to replace first or parse first
+     */
+    public boolean replaceFirst() {
+        return replaceFirst;
+    }
+    
+    /**
+     * Add an array with placeholders and values that should get replaced in the message
+     * @param replacements  The replacements, nth element is the placeholder, n+1th the value
+     * @return              The MineDown instance
+     */
+    public MineDown replace(String... replacements) {
+        reset();
+        replacer().replace(replacements);
+        return this;
+    }
+    
+    /**
+     * Add a map with placeholders and values that should get replaced in the message
+     * @param replacements  The replacements mapped placeholder to value
+     * @return              The MineDown instance
+     */
+    public MineDown replace(Map<String, ?> replacements) {
+        reset();
+        replacer().replace(replacements);
+        return this;
+    }
+
+    /**
+     * Add a placeholder to component mapping that should get replaced in the message
+     * @param placeholder   The placeholder to replace
+     * @param replacement   The replacement component
+     * @return              The Replacer instance
+     */
+    public MineDown replace(String placeholder, Component replacement) {
+        reset();
+        replacer().replace(placeholder, replacement);
+        return this;
+    }
+    
+    /**
+     * Set the placeholder indicator for both prefix and suffix
+     * @param placeholderIndicator  The character to use as a placeholder indicator
+     * @return                      The MineDown instance
+     */
+    public MineDown placeholderIndicator(String placeholderIndicator) {
+        placeholderPrefix(placeholderIndicator);
+        placeholderSuffix(placeholderIndicator);
+        return this;
+    }
+    
+    /**
+     * Set the placeholder indicator's prefix character
+     * @param placeholderPrefix     The character to use as the placeholder indicator's prefix
+     * @return                      The MineDown instance
+     */
+    public MineDown placeholderPrefix(String placeholderPrefix) {
+        reset();
+        replacer().placeholderPrefix(placeholderPrefix);
+        return this;
+    }
+    
+    /**
+     * Get the placeholder indicator's prefix character
+     * @return The placeholder indicator's prefix character
+     */
+    public String placeholderPrefix() {
+        return replacer().placeholderPrefix();
+    }
+    
+    /**
+     * Set the placeholder indicator's suffix character
+     * @param placeholderSuffix     The character to use as the placeholder indicator's suffix
+     * @return                      The MineDown instance
+     */
+    public MineDown placeholderSuffix(String placeholderSuffix) {
+        reset();
+        replacer().placeholderSuffix(placeholderSuffix);
+        return this;
+    }
+    
+    /**
+     * Get the placeholder indicator's suffix character
+     * @return The placeholder indicator's suffix character
+     */
+    public String placeholderSuffix() {
+        return replacer().placeholderSuffix();
+    }
+
+    /**
+     * Set whether or not the case of the placeholder should be ignored when replacing
+     * @param ignorePlaceholderCase Whether or not to ignore the case of the placeholders
+     * @return                      The MineDown instance
+     */
+    public MineDown ignorePlaceholderCase(boolean ignorePlaceholderCase) {
+        reset();
+        replacer().ignorePlaceholderCase(ignorePlaceholderCase);
+        return this;
+    }
+
+    /**
+     * Get whether or not the case of the placeholder should be ignored when replacing
+     * @return Whether or not to ignore the case of the placeholders
+     */
+    public boolean ignorePlaceholderCase() {
+        return replacer().ignorePlaceholderCase();
+    }
+
+    /**
+     * Enable or disable the translation of legacy color codes
+     * @param translateLegacyColors Whether or not to translate legacy color codes (Default: true)
+     * @return                      The MineDown instance
+     * @deprecated Use {@link #enable(MineDownParser.Option)} and {@link #disable(MineDownParser.Option)}
+     */
+    @Deprecated
+    public MineDown translateLegacyColors(boolean translateLegacyColors) {
+        reset();
+        parser().translateLegacyColors(translateLegacyColors);
+        return this;
+    }
+
+    /**
+     * Detect urls in strings and add events to them? (Default: true)
+     * @param enabled   Whether or not to detect URLs and add events to them
+     * @return          The MineDown instance
+     */
+    public MineDown urlDetection(boolean enabled) {
+        reset();
+        parser().urlDetection(enabled);
+        return this;
+    }
+
+    /**
+     * Automatically add http to values of open_url when there doesn't exist any? (Default: true)
+     * @param enabled   Whether or not to automatically add http when missing
+     * @return          The MineDown instance
+     */
+    public MineDown autoAddUrlPrefix(boolean enabled) {
+        reset();
+        parser().autoAddUrlPrefix(enabled);
+        return this;
+    }
+
+    /**
+     * The text to display when hovering over an URL
+     * @param text  The text to display when hovering over an URL
+     * @return      The MineDown instance
+     */
+    public MineDown urlHoverText(String text) {
+        reset();
+        parser().urlHoverText(text);
+        return this;
+    }
+
+    /**
+     * Set the max width the hover text should have.
+     * Minecraft itself will wrap after 60 characters.
+     * Won't apply if the text already includes new lines.
+     * @param hoverTextWidth   The url hover text length
+     * @return                  The MineDown instance
+     */
+    public MineDown hoverTextWidth(int hoverTextWidth) {
+        reset();
+        parser().hoverTextWidth(hoverTextWidth);
+        return this;
+    }
+
+    /**
+     * Enable an option. Unfilter it if you filtered it before.
+     * @param option    The option to enable
+     * @return          The MineDown instance
+     */
+    public MineDown enable(MineDownParser.Option option) {
+        reset();
+        parser().enable(option);
+        return this;
+    }
+
+    /**
+     * Disable an option. Disabling an option will stop the parser from replacing
+     * this option's chars in the string. Use {@link #filter(MineDownParser.Option)} to completely
+     * remove the characters used by this option from the message instead.
+     * @param option    The option to disable
+     * @return          The MineDown instance
+     */
+    public MineDown disable(MineDownParser.Option option) {
+        reset();
+        parser().disable(option);
+        return this;
+    }
+
+    /**
+     * Filter an option. This completely removes the characters of this option from
+     * the string ignoring whether the option is enabled or not.
+     * @param option    The option to add to the filter
+     * @return          The MineDown instance
+     */
+    public MineDown filter(MineDownParser.Option option) {
+        reset();
+        parser().filter(option);
+        return this;
+    }
+
+    /**
+     * Unfilter an option. Does not enable it!
+     * @param option    The option to remove from the filter
+     * @return          The MineDown instance
+     */
+    public MineDown unfilter(MineDownParser.Option option) {
+        reset();
+        parser().unfilter(option);
+        return this;
+    }
+    
+    /**
+     * Set a special character to replace color codes by if translating legacy colors is enabled.
+     * @param colorChar The character to use as a special color code. (Default: ampersand &amp;)
+    * @return           The MineDown instance
+     */
+    public MineDown colorChar(char colorChar) {
+        reset();
+        parser().colorChar(colorChar);
+        return this;
+    }
+
+    /**
+     * Get the set message that is to be parsed
+     * @return The to be parsed message
+     */
+    public String message() {
+        return this.message;
+    }
+
+    /**
+     * Set the message that is to be parsed
+     * @param message The message to be parsed
+     * @return The MineDown instance
+     */
+    public MineDown message(String message) {
+        this.message = message;
+        reset();
+        return this;
+    }
+
+    /**
+     * Get the replacer instance that is currently used
+     * @return The currently used replacer instance
+     */
+    public Replacer replacer() {
+        return this.replacer;
+    }
+
+    /**
+     * Get the parser instance that is currently used
+     * @return The currently used parser instance
+     */
+    public MineDownParser parser() {
+        return this.parser;
+    }
+
+    protected Component components() {
+        return this.components;
+    }
+
+    /**
+     * Copy all MineDown settings to a new instance
+     * @return The new MineDown instance with all settings copied
+     */
+    public MineDown copy() {
+        return new MineDown(message()).copy(this);
+    }
+
+    /**
+     * Copy all MineDown settings from another one
+     * @param from  The MineDown to copy from
+     * @return      This MineDown instance
+     */
+    public MineDown copy(MineDown from) {
+        replacer().copy(from.replacer());
+        parser().copy(from.parser());
+        return this;
+    }
+
+    /**
+     * Get the string that represents the format in MineDown
+     * @param format    The format
+     * @return          The MineDown string or an empty one if it's not a format
+     */
+    public static String getFormatString(TextDecoration format) {
+        switch (format) {
+            case BOLD:
+                return "**";
+            case ITALIC:
+                return "##";
+            case UNDERLINED:
+                return "__";
+            case STRIKETHROUGH:
+                return "~~";
+            case OBFUSCATED:
+                return "??";
+        }
+        return "";
+    }
+    
+    /**
+     * Get the TextColor format from a MineDown string
+     * @param c The character
+     * @return  The TextColor of that format or <code>null</code> it none was found
+     */
+    public static TextDecoration getFormatFromChar(char c) {
+        switch (c) {
+            case '~':
+                return TextDecoration.STRIKETHROUGH;
+            case '_':
+                return TextDecoration.UNDERLINED;
+            case '*':
+                return TextDecoration.BOLD;
+            case '#':
+                return TextDecoration.ITALIC;
+            case '?':
+                return TextDecoration.OBFUSCATED;
+        }
+        return null;
+    }
+
+    /**
+     * Escape all MineDown formatting in a string. This will escape backslashes too!
+     * @param string    The string to escape in
+     * @return          The string with formatting escaped
+     */
+    public static String escape(String string) {
+        return new MineDown(string).parser().escape(string);
+    }
+}

--- a/common/src/main/java/de/themoep/minedown/adventure/MineDownParser.java
+++ b/common/src/main/java/de/themoep/minedown/adventure/MineDownParser.java
@@ -1,0 +1,1502 @@
+package de.themoep.minedown.adventure;
+
+/*
+ * Copyright (c) 2020 Max Lee (https://github.com/Phoenix616)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import net.kyori.adventure.key.InvalidKeyException;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.nbt.api.BinaryTagHolder;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentBuilder;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.format.TextFormat;
+
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.PrimitiveIterator;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static de.themoep.minedown.adventure.MineDown.ATLAS_PREFIX;
+import static de.themoep.minedown.adventure.MineDown.COLOR_PREFIX;
+import static de.themoep.minedown.adventure.MineDown.FONT_PREFIX;
+import static de.themoep.minedown.adventure.MineDown.FORMAT_PREFIX;
+import static de.themoep.minedown.adventure.MineDown.HAT_PREFIX;
+import static de.themoep.minedown.adventure.MineDown.HOVER_PREFIX;
+import static de.themoep.minedown.adventure.MineDown.INSERTION_PREFIX;
+import static de.themoep.minedown.adventure.MineDown.PAYLOAD_PREFIX;
+import static de.themoep.minedown.adventure.MineDown.PLAYER_HEAD_PREFIX;
+import static de.themoep.minedown.adventure.MineDown.PROFILE_PREFIX;
+import static de.themoep.minedown.adventure.MineDown.SHADOW_ALPHA;
+import static de.themoep.minedown.adventure.MineDown.SHADOW_PREFIX;
+import static de.themoep.minedown.adventure.MineDown.SPRITE_PREFIX;
+import static de.themoep.minedown.adventure.MineDown.TEXTURE_PREFIX;
+import static de.themoep.minedown.adventure.MineDown.TRANSLATE_PREFIX;
+import static de.themoep.minedown.adventure.MineDown.WITH_PREFIX;
+import static net.kyori.adventure.text.format.TextColor.HEX_PREFIX;
+
+public class MineDownParser {
+    private static final String RAINBOW = "rainbow";
+
+    /**
+     * The character to use as a special color code. (Default: ampersand &amp;)
+     */
+    private char colorChar = '&';
+
+    /**
+     * All enabled options
+     */
+    private Set<Option> enabledOptions = EnumSet.of(
+            Option.LEGACY_COLORS,
+            Option.SIMPLE_FORMATTING,
+            Option.ADVANCED_FORMATTING
+    );
+
+    /**
+     * All filters
+     */
+    private Set<Option> filteredOptions = EnumSet.noneOf(Option.class);
+
+    /**
+     * Whether to accept malformed strings or not (Default: false)
+     */
+    private boolean lenient = false;
+
+    /**
+     * Detect urls in strings and add events to them? (Default: true)
+     */
+    private boolean urlDetection = true;
+
+    /**
+     * The text to display when hovering over an URL. Has a %url% placeholder.
+     */
+    private String urlHoverText = "Click to open url";
+
+    /**
+     * Automatically add http to values of open_url when there doesn't exist any? (Default: true)
+     */
+    private boolean autoAddUrlPrefix = true;
+
+    /**
+     * The max width the hover text should have.
+     * Minecraft itself will wrap after 60 characters.
+     * Won't apply if the text already includes new lines.
+     */
+    private int hoverTextWidth = 60;
+
+    public static final Pattern URL_PATTERN = Pattern.compile("^(?:(https?)://)?([-\\w_\\.]+\\.[a-z]{2,18})(/\\S*)?$");
+
+    private ComponentBuilder<?, ?> builder;
+    private StringBuilder value;
+    private String translationKey;
+    private List<Component> translationArgs = new ArrayList<>();
+    private String font;
+    private Key sprite;
+    private Key atlas;
+    private Object playerHead;
+    private String insertion;
+    private Integer rainbowPhase;
+    private List<Map.Entry<TextColor, Boolean>> colors;
+    private boolean colorsAreLegacy = false;
+    private Object shadow;
+    private Map<TextDecoration, Boolean> format;
+    private boolean formattingIsLegacy = false;
+    private ClickEvent clickEvent;
+    private HoverEvent hoverEvent;
+
+    public MineDownParser() {
+        reset();
+    }
+
+    /**
+     * Create a ComponentBuilder by parsing a {@link MineDown} message
+     * @param message The message to parse
+     * @return The parsed ComponentBuilder
+     * @throws IllegalArgumentException Thrown when a parsing error occurs and lenient is set to false
+     */
+    public ComponentBuilder parse(String message) throws IllegalArgumentException {
+        Matcher urlMatcher = urlDetection() ? URL_PATTERN.matcher(message) : null;
+        boolean escaped = false;
+        for (int i = 0; i < message.length(); i++) {
+            char c = message.charAt(i);
+
+            boolean isEscape = c == '\\' && i + 1 < message.length();
+            boolean isColorCode = isEnabled(Option.LEGACY_COLORS)
+                    && i + 1 < message.length() && (c == '§' || c == colorChar());
+            int eventEndIndex = -1;
+            String eventDefinition = null;
+            if (!escaped && isEnabled(Option.ADVANCED_FORMATTING) && c == '[') {
+                eventEndIndex = Util.getUnescapedEndIndex(message, '[', ']', i);
+                if (eventEndIndex != -1 && message.length() > eventEndIndex + 1 && message.charAt(eventEndIndex + 1) == '(') {
+                    int definitionClose = Util.getUnescapedEndIndex(message, '(', ')', eventEndIndex + 1);
+                    if (definitionClose != -1) {
+                        eventDefinition = message.substring(eventEndIndex + 2, definitionClose);
+                    }
+                }
+            }
+            boolean isFormatting = isEnabled(Option.SIMPLE_FORMATTING)
+                    && (c == '_' || c == '*' || c == '~' || c == '?' || c == '#') && Util.isDouble(message, i)
+                    && message.indexOf(String.valueOf(c) + String.valueOf(c), i + 2) != -1;
+
+            if (escaped) {
+                escaped = false;
+
+                // Escaping
+            } else if (isEscape) {
+                escaped = true;
+                continue;
+
+                // Legacy color codes
+            } else if (isColorCode) {
+                i++;
+                char code = message.charAt(i);
+                if (code >= 'A' && code <= 'Z') {
+                    code += 32;
+                }
+                Integer rainbowPhase = null;
+                List<Map.Entry<Object, Boolean>> encoded = null;
+                Option filterOption = null;
+                StringBuilder colorString = new StringBuilder();
+                for (int j = i; j < message.length(); j++) {
+                    char c1 = message.charAt(j);
+                    if (c1 == c && colorString.length() > 1) {
+                        String colorStr = colorString.toString();
+                        rainbowPhase = parseRainbow(colorStr, "", lenient());
+                        if (rainbowPhase == null && !colorStr.contains("=")) {
+                            encoded = parseFormat(colorStr, "", true);
+                            if (encoded.isEmpty()) {
+                                encoded = null;
+                            } else {
+                                filterOption = Option.SIMPLE_FORMATTING;
+                                i = j;
+                            }
+                        } else {
+                            filterOption = Option.SIMPLE_FORMATTING;
+                            i = j;
+                        }
+                        break;
+                    }
+                    if (c1 != '_' && c1 != '#' && c1 != '-' && c1 != ',' && c1 != ':' &&
+                            (c1 < 'A' || c1 > 'Z') && (c1 < 'a' || c1 > 'z') && (c1 < '0' || c1 > '9')) {
+                        break;
+                    }
+                    colorString.append(c1);
+                }
+                if (rainbowPhase == null && encoded == null) {
+                    Object format = Util.getFormatFromLegacy(code);
+                    if (format != null) {
+                        filterOption = Option.LEGACY_COLORS;
+                        encoded = new ArrayList<>();
+                        encoded.add(new AbstractMap.SimpleEntry<>(format, true));
+                    }
+                }
+
+                if (rainbowPhase != null || encoded != null) {
+                    if (!isFiltered(filterOption)) {
+                        if (encoded != null && encoded.size() == 1) {
+                            Map.Entry<Object, Boolean> single = encoded.iterator().next();
+                            if (single.getKey() == Util.TextControl.RESET) {
+                                if (builder() == null && ((format() != null && !format().isEmpty()) || (colors() != null && !colors().isEmpty()))) {
+                                    builder(Component.text());
+                                }
+                                colorsAreLegacy(true);
+                                formattingIsLegacy(true);
+                                appendValue();
+                                colors(new ArrayList<>());
+                                rainbowPhase(null);
+                                format(new HashMap<>());
+                            } else if (single.getKey() instanceof TextColor) {
+                                colorsAreLegacy(true);
+                                if (value().length() > 0) {
+                                    if (builder() == null && format() != null && !format().isEmpty()) {
+                                        builder(Component.text());
+                                    }
+                                    appendValue();
+                                }
+                                colors(new ArrayList<>());
+                                colors().add(new AbstractMap.SimpleImmutableEntry<>((TextColor) single.getKey(), single.getValue()));
+                                rainbowPhase(null);
+                                if (formattingIsLegacy()) {
+                                    format(new HashMap<>());
+                                }
+                            } else if (single.getKey() instanceof TextDecoration) {
+                                if (value.length() > 0) {
+                                    appendValue();
+                                }
+                                formattingIsLegacy(true);
+                                format().put((TextDecoration) single.getKey(), single.getValue());
+                            }
+                        } else {
+                            if (value().length() > 0) {
+                                appendValue();
+                            }
+                            rainbowPhase(rainbowPhase);
+                            if (encoded != null) {
+                                List<Map.Entry<TextColor, Boolean>> colors = new ArrayList<>();
+                                for (Map.Entry<Object, Boolean> e : encoded) {
+                                    if (e.getKey() instanceof TextColor) {
+                                        colors.add(new AbstractMap.SimpleImmutableEntry<>((TextColor) e.getKey(), e.getValue()));
+                                    }
+                                }
+                                colors(colors);
+                            } else {
+                                colors(null);
+                            }
+                            if (formattingIsLegacy()) {
+                                format(new HashMap<>());
+                            }
+                        }
+                    }
+                } else {
+                    value().append(c).append(code);
+                }
+                continue;
+
+                // Events
+            } else if (eventEndIndex != -1 && eventDefinition != null) {
+                appendValue();
+                if (!isFiltered(Option.ADVANCED_FORMATTING) && !eventDefinition.isEmpty()) {
+                    append(parseEvent(message.substring(i + 1, eventEndIndex), eventDefinition));
+                } else {
+                    append(copy(true).parse(message.substring(i + 1, eventEndIndex)));
+                }
+                i = eventEndIndex + 2 + eventDefinition.length();
+                continue;
+
+                // Simple formatting
+            } else if (isFormatting) {
+                int endIndex = message.indexOf(String.valueOf(c) + String.valueOf(c), i + 2);
+                Map<TextDecoration, Boolean> formats = new HashMap<>(format());
+                if (!isFiltered(Option.SIMPLE_FORMATTING)) {
+                    formats.put(MineDown.getFormatFromChar(c), true);
+                }
+                formattingIsLegacy(false);
+                appendValue();
+                append(copy(true).format(formats).parse(message.substring(i + 2, endIndex)));
+                i = endIndex + 1;
+                continue;
+            }
+
+            // URL
+            if (urlDetection() && urlMatcher != null) {
+                int urlEnd = message.indexOf(' ', i);
+                if (urlEnd == -1) {
+                    urlEnd = message.length();
+                }
+                if (urlMatcher.region(i, urlEnd).find()) {
+                    appendValue();
+                    value(new StringBuilder(message.substring(i, urlEnd)));
+                    appendValue();
+                    i = urlEnd - 1;
+                    continue;
+                }
+            }
+
+            // It's normal text, just append the character
+            value().append(message.charAt(i));
+        }
+        if (escaped) {
+            value().append('\\');
+        }
+        appendValue();
+        if (builder() == null) {
+            builder(Component.text());
+        }
+        return builder();
+    }
+
+    private void append(ComponentBuilder<?, ?> builder) {
+        if (builder() == null) {
+            builder(Component.text().append(builder));
+        } else {
+            builder().append(builder);
+        }
+    }
+
+    private void appendValue() {
+        ComponentBuilder<?, ?> builder;
+        List<TextColor> applicableColors;
+        long valueCodepointLength = value().length();
+        // If the value is empty don't add anything
+        if (valueCodepointLength == 0 && translationKey() == null && sprite() == null && playerHead() == null) {
+            return;
+        }
+        if (rainbowPhase() != null) {
+            // Rainbow colors
+            valueCodepointLength = value().codePoints().count();
+            applicableColors = Util.createRainbow(valueCodepointLength, rainbowPhase());
+        } else if (colors() != null) {
+            if (colors().size() > 1) {
+                valueCodepointLength = value().codePoints().count();
+                applicableColors = Util.createGradient(
+                        valueCodepointLength,
+                        colors.stream().filter(Map.Entry::getValue).map(Map.Entry::getKey).collect(Collectors.toList())
+                );
+            } else {
+                applicableColors = colors.stream().map(Map.Entry::getKey).collect(Collectors.toCollection(ArrayList::new));
+            }
+        } else {
+            applicableColors = new ArrayList<>();
+        }
+
+        if (applicableColors.size() > 1 && translationKey() == null && sprite() == null && playerHead() == null) {
+            // Colors need to have a gradient/rainbow applied
+            builder = Component.text();
+        } else {
+            // Single color mode
+            if (translationKey() != null) {
+                try {
+                    builder = Component.translatable(translationKey(), value().toString(), translationArgs()).toBuilder();
+                } catch (NoSuchMethodError e) {
+                    // Adventure version without fallback
+                    builder = Component.translatable(translationKey(), translationArgs()).toBuilder();
+                }
+                if (!applicableColors.isEmpty()) {
+                    // translatable components can only have one color
+                    builder.color(applicableColors.get(0));
+                }
+            } else if (playerHead() != null) {
+                builder = AdventureCompat.playerHeadComponent(playerHead()).toBuilder();
+            } else if (sprite() != null) {
+                builder = AdventureCompat.spriteComponent(atlas(), sprite()).toBuilder();
+                if (!applicableColors.isEmpty()) {
+                    // object components can only have one color
+                    builder.color(applicableColors.get(0));
+                }
+            } else {
+                builder = Component.text(value().toString()).toBuilder();
+                if (applicableColors.size() == 1) {
+                    builder.color(applicableColors.get(0));
+                }
+            }
+        }
+
+        if (shadow() != null) {
+            AdventureCompat.applyShadow(builder, shadow());
+        }
+
+        if (font() != null) {
+            builder.font(Key.key(font()));
+        }
+        builder.insertion(insertion());
+        Util.applyFormat(builder, format);
+        if (urlDetection() && URL_PATTERN.matcher(value).matches()) {
+            String v = value.toString();
+            if (!v.startsWith("http://") && !v.startsWith("https://")) {
+                v = "http://" + v;
+            }
+            builder.clickEvent(ClickEvent.openUrl(v));
+            if (urlHoverText() != null && !urlHoverText().isEmpty()) {
+                builder.hoverEvent(HoverEvent.showText(
+                        new MineDown(urlHoverText()).replace("url", value.toString()).toComponent()
+                ));
+            }
+        }
+        if (clickEvent() != null) {
+            builder.clickEvent(clickEvent());
+        }
+        if (hoverEvent() != null) {
+            builder.hoverEvent(hoverEvent());
+        }
+
+        if (applicableColors.size() > 1) {
+            int stepLength = (int) Math.round((double) valueCodepointLength / applicableColors.size());
+            ComponentBuilder<?, ?> component = Component.empty().toBuilder();
+
+            StringBuilder sb = new StringBuilder();
+            int colorIndex = 0;
+            int steps = 0;
+
+            for (PrimitiveIterator.OfInt it = value().codePoints().iterator(); it.hasNext(); ) {
+                sb.appendCodePoint(it.next());
+                if (++steps == stepLength) {
+                    steps = 0;
+                    component.append(Component.text(sb.toString()).color(applicableColors.get(colorIndex++)));
+                    sb = new StringBuilder();
+                }
+            }
+            builder.append(component);
+        }
+
+        if (builder() == null && (formattingIsLegacy() || colorsAreLegacy())) {
+            builder(Component.text());
+        }
+
+        if (builder() == null) {
+            builder(builder);
+        } else {
+            builder().append(builder);
+        }
+        value(new StringBuilder());
+    }
+
+    /**
+     * Parse a {@link MineDown} event string
+     * @param text        The display text
+     * @param definitions The event definition string
+     * @return The parsed ComponentBuilder for this string
+     */
+    public ComponentBuilder parseEvent(String text, String definitions) {
+        List<String> defParts = new ArrayList<>();
+        if (definitions.startsWith(" ")) {
+            defParts.add("");
+        }
+        Collections.addAll(defParts, definitions.split(" "));
+        if (definitions.endsWith(" ")) {
+            defParts.add("");
+        }
+        Integer rainbowPhase = null;
+        List<Map.Entry<TextColor, Boolean>> colors = null;
+        Object shadowColor = null;
+        String translationKey = null;
+        List<Component> translationArgs = new ArrayList<>();
+        String font = null;
+        Key sprite = null;
+        Key atlas = null;
+        Object playerHead = null;
+        String insertion = null;
+        BinaryTagHolder payloadBinaryData = null;
+        Map<TextDecoration, Boolean> formats = new HashMap<>();
+        ClickEvent clickEvent = null;
+        String clickValue = null;
+        String customClickKey = null;
+        HoverEvent hoverEvent = null;
+
+        int formatEnd = -1;
+
+        for (AtomicInteger i = new AtomicInteger(); i.get() < defParts.size(); i.incrementAndGet()) {
+            String definition = defParts.get(i.get());
+            String defLowerCase = definition.toLowerCase(Locale.ROOT);
+            Integer parsedRainbowPhase = parseRainbow(definition, "", lenient());
+            if (parsedRainbowPhase != null) {
+                rainbowPhase = parsedRainbowPhase;
+                continue;
+            } else if (!definition.contains("=")) {
+                List<Map.Entry<Object, Boolean>> parsed = parseFormat(definition, "", true);
+                if (parsed != null && !parsed.isEmpty()) {
+                    for (Map.Entry<Object, Boolean> e : parsed) {
+                        if (e.getKey() instanceof TextColor) {
+                            if (colors == null) {
+                                colors = new ArrayList<>();
+                            }
+                            colors.add(new AbstractMap.SimpleImmutableEntry<>((TextColor) e.getKey(), e.getValue()));
+                        } else if (e.getKey() instanceof TextDecoration) {
+                            formats.put((TextDecoration) e.getKey(), e.getValue());
+                        }
+                    }
+                    formatEnd = i.get();
+                    continue;
+                }
+            }
+
+            if (defLowerCase.startsWith(TRANSLATE_PREFIX)) {
+                translationKey = definition.substring(TRANSLATE_PREFIX.length());
+                continue;
+            }
+
+            if (defLowerCase.startsWith(WITH_PREFIX)) {
+                String[] args = getValue(i, definition.substring(WITH_PREFIX.length()), defParts, true).split("(?<!\\\\),");
+                for (String arg : args) {
+                    translationArgs.add(copy(false).urlDetection(false).parse(arg).build());
+                }
+                continue;
+            }
+
+            if (defLowerCase.startsWith(FONT_PREFIX)) {
+                font = definition.substring(FONT_PREFIX.length());
+                continue;
+            }
+
+            if (defLowerCase.startsWith(SPRITE_PREFIX)) {
+                try {
+                    sprite = Key.key(definition.substring(SPRITE_PREFIX.length()));
+                } catch (InvalidKeyException e) {
+                     if (!lenient()) {
+                        throw new IllegalArgumentException("Invalid key " + definition.substring(SPRITE_PREFIX.length()) + " for sprite!", e);
+                    }
+                }
+                continue;
+            }
+
+            if (defLowerCase.startsWith(ATLAS_PREFIX)) {
+                try {
+                    atlas = Key.key(definition.substring(ATLAS_PREFIX.length()));
+                } catch (InvalidKeyException e) {
+                    if (!lenient()) {
+                        throw new IllegalArgumentException("Invalid key " + definition.substring(ATLAS_PREFIX.length()) + " for atlas!", e);
+                    }
+                }
+                continue;
+            }
+
+            if (defLowerCase.startsWith(PLAYER_HEAD_PREFIX)) {
+                String playerHeadPart = definition.substring(PLAYER_HEAD_PREFIX.length());
+                if (playerHead == null) {
+                    playerHead = AdventureCompat.playerHead();
+                }
+                if (playerHeadPart.length() == 36) {
+                    AdventureCompat.playerHeadId(playerHead, UUID.fromString(playerHeadPart));
+                } else if (playerHeadPart.contains(":") || playerHeadPart.contains("/")) {
+                    AdventureCompat.playerHeadTexture(playerHead, Key.key(playerHeadPart));
+                } else if (playerHeadPart.length() <= 16) {
+                    AdventureCompat.playerHeadName(playerHead, playerHeadPart);
+                } else {
+                    String decoded = new String(Base64.getDecoder().decode(playerHeadPart));
+                    if (decoded.startsWith("{\"textures\"") && decoded.endsWith("}")) {
+                        AdventureCompat.playerHeadProperty(playerHead, "textures", playerHeadPart, null);
+                    } else if (!lenient()) {
+                        throw new IllegalArgumentException("Provided an invalid value for a player head in " + definition.substring(PLAYER_HEAD_PREFIX.length()));
+                    }
+                }
+                continue;
+            }
+
+            if (defLowerCase.startsWith(TEXTURE_PREFIX)) {
+                if (playerHead == null) {
+                    playerHead = AdventureCompat.playerHead();
+                }
+                AdventureCompat.playerHeadTexture(playerHead, Key.key(definition.substring(TEXTURE_PREFIX.length())));
+                continue;
+            }
+
+            if (defLowerCase.startsWith(HAT_PREFIX)) {
+                if (playerHead == null) {
+                    playerHead = AdventureCompat.playerHead();
+                }
+                AdventureCompat.playerHeadHat(playerHead, Boolean.parseBoolean(definition.substring(HAT_PREFIX.length())));
+                continue;
+            }
+
+            if (defLowerCase.startsWith(PROFILE_PREFIX) && playerHead != null) {
+                String valuePart = definition.substring(PROFILE_PREFIX.length());
+                if (!valuePart.startsWith("{") || !valuePart.endsWith("}")) {
+                    if (!lenient()) {
+                        throw new IllegalArgumentException("Profile information need to be wrapped in curly braces. '" + definition.substring(PROFILE_PREFIX.length()) + "' was not!");
+                    }
+                    continue;
+                }
+
+                if (playerHead == null) {
+                    playerHead = AdventureCompat.playerHead();
+                }
+
+                if (valuePart.startsWith("{{") && valuePart.endsWith("}}")) {
+                    valuePart = valuePart.substring(1, valuePart.length() - 1);
+                }
+
+                String[] args = valuePart.substring(1, valuePart.length() - 1).split("},\\{");
+
+                for (String arg : args) {
+                    String name = null;
+                    String value = null;
+                    String signature = null;
+                    String[] argParts = arg.split(",");
+                    for (String part : argParts) {
+                        String[] keyValue = part.split("=");
+                        if (keyValue[0].equals("signature")) {
+                            signature = keyValue[1];
+                        } else {
+                            name = keyValue[0];
+                            value = keyValue[1];
+                        }
+                    }
+                    if (name != null && value != null) {
+                        AdventureCompat.playerHeadProperty(playerHead, name, value, signature);
+                    }
+                }
+                continue;
+            }
+
+            if (defLowerCase.startsWith(INSERTION_PREFIX)) {
+                insertion = getValue(i, definition.substring(INSERTION_PREFIX.length()), defParts, true);
+                continue;
+            }
+
+            if (defLowerCase.startsWith(PAYLOAD_PREFIX)) {
+                payloadBinaryData = BinaryTagHolder.binaryTagHolder(getValue(i, definition.substring(PAYLOAD_PREFIX.length()), defParts, true));
+                if (clickEvent != null) {
+                    if (customClickKey != null) {
+                        clickEvent = Util.createClickEvent(clickEvent.action(), customClickKey, payloadBinaryData);
+                    }
+                } else if (!lenient()) {
+                    throw new IllegalArgumentException("custom=<key> click event needs to be specified before the payload tag! " + definition);
+                }
+                continue;
+            }
+
+            if (defLowerCase.startsWith(COLOR_PREFIX)) {
+                Integer colorRainbowPhase = parseRainbow(definition, COLOR_PREFIX, lenient());
+                if (colorRainbowPhase == null) {
+                    List<Map.Entry<Object, Boolean>> parsed = parseFormat(definition, COLOR_PREFIX, lenient());
+                    colors = new ArrayList<>();
+                    for (Map.Entry<Object, Boolean> e : parsed) {
+                        if (e.getKey() instanceof TextColor) {
+                            colors.add(new AbstractMap.SimpleImmutableEntry<>((TextColor) e.getKey(), e.getValue()));
+                        } else if (!lenient()) {
+                            throw new IllegalArgumentException(e + "  is a format and not a color!");
+                        }
+                    }
+                } else {
+                    rainbowPhase = colorRainbowPhase;
+                }
+                formatEnd = i.get();
+                continue;
+            }
+
+            if (defLowerCase.startsWith(SHADOW_PREFIX)) {
+                Object parsed = parseShadow(definition, SHADOW_PREFIX, lenient());
+                if (parsed != null) {
+                    shadowColor = parsed;
+                } else if (!lenient()) {
+                    throw new IllegalArgumentException("Invalid shadow definition: " + definition);
+                }
+                formatEnd = i.get();
+                continue;
+            }
+
+            if (definition.toLowerCase(Locale.ROOT).startsWith(FORMAT_PREFIX)) {
+                List<Map.Entry<Object, Boolean>> parsed = parseFormat(definition, FORMAT_PREFIX, lenient());
+                for (Map.Entry<Object, Boolean> e : parsed) {
+                    if (e.getKey() instanceof TextDecoration) {
+                        formats.put((TextDecoration) e.getKey(), e.getValue());
+                    } else if (!lenient()) {
+                        throw new IllegalArgumentException(e + " is a color and not a format!");
+                    }
+                }
+                formatEnd = i.get();
+                continue;
+            }
+
+            if (i.get() == formatEnd + 1 && URL_PATTERN.matcher(definition).matches()) {
+                if (!definition.startsWith("http://") && !definition.startsWith("https://")) {
+                    definition = "http://" + definition;
+                }
+                clickEvent = ClickEvent.openUrl(definition);
+                clickValue = definition;
+                continue;
+            }
+
+            ClickEvent.Action clickAction = definition.startsWith("/") ? ClickEvent.Action.NAMES.value("run_command") : null;
+            HoverEvent.Action hoverAction = null;
+            if (definition.toLowerCase(Locale.ROOT).startsWith(HOVER_PREFIX)) {
+                hoverAction = HoverEvent.Action.SHOW_TEXT;
+            }
+            String[] parts = definition.split("=", 2);
+            if (hoverAction == null) {
+                hoverAction = HoverEvent.Action.NAMES.value(parts[0].toLowerCase(Locale.ROOT));
+            }
+            if (clickAction == null) {
+                try {
+                    clickAction = ClickEvent.Action.NAMES.value(parts[0].toLowerCase(Locale.ROOT));
+                } catch (IllegalArgumentException ignored) {
+                }
+            }
+
+            String valueStr = getValue(i, parts.length > 1 ? parts[1] : "", defParts, clickAction != null || hoverAction != null);
+
+            if (clickAction != null) {
+                if (autoAddUrlPrefix() && Util.actionName(clickAction).equals("open_url") && !valueStr.startsWith("http://") && !valueStr.startsWith("https://")) {
+                    valueStr = "http://" + valueStr;
+                }
+                try {
+                    clickEvent = Util.createClickEvent(clickAction, valueStr, payloadBinaryData);
+                    clickValue = valueStr;
+                    customClickKey = "custom".equals(Util.actionName(clickAction)) ? valueStr : null;
+                } catch (IllegalArgumentException e) {
+                    if (!lenient()) {
+                        throw e;
+                    }
+                }
+            } else if (hoverAction == null) {
+                hoverAction = HoverEvent.Action.SHOW_TEXT;
+            }
+            if (hoverAction != null) {
+                if (hoverAction == HoverEvent.Action.SHOW_TEXT) {
+                    hoverEvent = HoverEvent.showText(copy(false)
+                            .urlDetection(false)
+                            .parse(Util.wrap(valueStr, hoverTextWidth()))
+                            .build()
+                    );
+                } else if (hoverAction == HoverEvent.Action.SHOW_ENTITY) {
+                    String[] valueParts = valueStr.split(":", 2);
+                    try {
+                        String[] additionalParts = valueParts[1].split(" ", 2);
+                        if (!additionalParts[0].contains(":")) {
+                            additionalParts[0] = "minecraft:" + additionalParts[0];
+                        }
+                        hoverEvent = HoverEvent.showEntity(HoverEvent.ShowEntity.showEntity(
+                                Key.key(additionalParts[0]), UUID.fromString(valueParts[0]),
+                                additionalParts.length > 1 && additionalParts[1] != null ?
+                                        copy(false).urlDetection(false).parse(additionalParts[1]).build() : null
+                        ));
+                    } catch (Exception e) {
+                        if (!lenient()) {
+                            if (valueParts.length < 2) {
+                                throw new IllegalArgumentException("Invalid entity definition. Needs to be of format uuid:id or uuid:namespace:id!");
+                            }
+                            throw new IllegalArgumentException(e.getMessage());
+                        }
+                    }
+                } else if (hoverAction == HoverEvent.Action.SHOW_ITEM) {
+                    String[] valueParts = valueStr.split(" ", 2);
+                    String id = valueParts[0];
+                    if (!id.contains(":")) {
+                        id = "minecraft:" + id;
+                    }
+                    int count = 1;
+                    int countIndex = valueParts[0].indexOf('*');
+                    if (countIndex > 0 && countIndex + 1 < valueParts[0].length()) {
+                        try {
+                            count = Integer.parseInt(valueParts[0].substring(countIndex + 1));
+                            id = valueParts[0].substring(0, countIndex);
+                        } catch (NumberFormatException e) {
+                            if (!lenient()) {
+                                throw new IllegalArgumentException(e.getMessage());
+                            }
+                        }
+                    }
+                    BinaryTagHolder tag = null;
+                    if (valueParts.length > 1 && valueParts[1] != null) {
+                        tag = BinaryTagHolder.binaryTagHolder(valueParts[1]);
+                    }
+
+                    try {
+                        hoverEvent = HoverEvent.showItem(HoverEvent.ShowItem.showItem(
+                                Key.key(id), count, tag
+                        ));
+                    } catch (Exception e) {
+                        if (!lenient()) {
+                            throw new IllegalArgumentException(e.getMessage());
+                        }
+                    }
+                }
+            }
+        }
+
+        if (clickEvent != null && hoverEvent == null) {
+            String payloadDescription = clickValue != null ? " " + clickValue : "";
+            hoverEvent = HoverEvent.showText(Component.text()
+                    .append(Component.text(Util.actionName(clickEvent.action()).replace('_', ' ')))
+                    .color(NamedTextColor.BLUE)
+                    .append(Component.text(payloadDescription)).color(NamedTextColor.WHITE)
+                    .build()
+            );
+        }
+
+        return copy()
+                .urlDetection(false)
+                .translationKey(translationKey)
+                .translationArgs(translationArgs)
+                .rainbowPhase(rainbowPhase)
+                .colors(colors)
+                .shadow(shadowColor)
+                .font(font)
+                .sprite(sprite)
+                .atlas(atlas)
+                .playerHead(playerHead)
+                .insertion(insertion)
+                .format(formats)
+                .clickEvent(clickEvent)
+                .hoverEvent(hoverEvent)
+                .parse(text);
+    }
+
+    private String getValue(AtomicInteger i, String firstPart, List<String> defParts, boolean hasAction) {
+        int bracketDepth = firstPart.startsWith("{") && hasAction ? 1 : 0;
+
+        StringBuilder value = new StringBuilder();
+        if (!firstPart.isEmpty() && hasAction) {
+            if (bracketDepth > 0) {
+                value.append(firstPart.substring(1));
+            } else {
+                value.append(firstPart);
+            }
+        } else {
+            value.append(defParts.get(i.get()));
+        }
+
+        for (i.incrementAndGet(); i.get() < defParts.size(); i.incrementAndGet()) {
+            String part = defParts.get(i.get());
+            if (bracketDepth == 0) {
+                int equalsIndex = part.indexOf('=');
+                if (equalsIndex > 0 && !Util.isEscaped(part, equalsIndex)) {
+                    i.decrementAndGet();
+                    break;
+                }
+            }
+            value.append(" ");
+            if (bracketDepth > 0) {
+                int startBracketIndex = part.indexOf("={");
+                if (startBracketIndex > 0 && !Util.isEscaped(part, startBracketIndex) && !Util.isEscaped(part, startBracketIndex + 1)) {
+                    bracketDepth++;
+                }
+                if (part.endsWith("}") && !Util.isEscaped(part, part.length() - 1)) {
+                    bracketDepth--;
+                    if (bracketDepth == 0) {
+                        value.append(part, 0, part.length() - 1);
+                        break;
+                    }
+                }
+            }
+            value.append(part);
+        }
+
+        String valueString = value.toString();
+
+        while (bracketDepth > 0) {
+            bracketDepth--;
+            if (valueString.endsWith("}") && !valueString.endsWith("\\}")) {
+                valueString = valueString.substring(0, valueString.length() - 1);
+            } else {
+                valueString = "{" + valueString;
+            }
+        }
+
+        return valueString.replace("\\{", "{").replace("\\}", "}");
+    }
+
+    protected ComponentBuilder<?,?> builder() {
+        return this.builder;
+    }
+
+    protected MineDownParser builder(ComponentBuilder builder) {
+        this.builder = builder;
+        return this;
+    }
+
+    protected MineDownParser value(StringBuilder value) {
+        this.value = value;
+        return this;
+    }
+
+    protected StringBuilder value() {
+        return this.value;
+    }
+
+    public MineDownParser translationKey(String translationKey) {
+        this.translationKey = translationKey;
+        return this;
+    }
+
+    public String translationKey() {
+        return translationKey;
+    }
+
+    public MineDownParser translationArgs(List<Component> translationArgs) {
+        this.translationArgs = translationArgs;
+        return this;
+    }
+
+    public List<Component> translationArgs() {
+        return translationArgs;
+    }
+
+    private MineDownParser font(String font) {
+        this.font = font;
+        return this;
+    }
+    protected String font() {
+        return this.font;
+    }
+
+    private MineDownParser sprite(Key sprite) {
+        this.sprite = sprite;
+        return this;
+    }
+
+    protected Key sprite() {
+        return this.sprite;
+    }
+
+    private MineDownParser atlas(Key atlas) {
+        this.atlas = atlas;
+        return this;
+    }
+
+    protected Key atlas() {
+        return this.atlas;
+    }
+
+    private MineDownParser playerHead(Object playerHead) {
+        this.playerHead = playerHead;
+        return this;
+    }
+
+    protected Object playerHead() {
+        return this.playerHead;
+    }
+
+    private MineDownParser insertion(String insertion) {
+        this.insertion = insertion;
+        return this;
+    }
+
+    protected String insertion() {
+        return this.insertion;
+    }
+
+    protected MineDownParser colors(List<Map.Entry<TextColor, Boolean>> colors) {
+        this.colors = colors;
+        return this;
+    }
+
+    protected MineDownParser colorsAreLegacy(boolean colorsAreLegacy) {
+        this.colorsAreLegacy = colorsAreLegacy;
+        return this;
+    }
+
+    protected boolean colorsAreLegacy() {
+        return colorsAreLegacy;
+    }
+
+    protected MineDownParser rainbowPhase(Integer rainbowPhase) {
+        this.rainbowPhase = rainbowPhase;
+        return this;
+    }
+
+    protected Integer rainbowPhase() {
+        return this.rainbowPhase;
+    }
+
+    protected List<Map.Entry<TextColor, Boolean>> colors() {
+        return this.colors;
+    }
+
+    protected MineDownParser shadow(Object shadow) {
+        this.shadow = shadow;
+        return this;
+    }
+
+    protected Object shadow() {
+        return this.shadow;
+    }
+
+    protected MineDownParser format(Map<TextDecoration, Boolean> format) {
+        this.format = format;
+        return this;
+    }
+
+    protected Map<TextDecoration, Boolean> format() {
+        return this.format;
+    }
+
+    protected MineDownParser formattingIsLegacy(boolean formattingIsLegacy) {
+        this.formattingIsLegacy = formattingIsLegacy;
+        return this;
+    }
+
+    protected boolean formattingIsLegacy() {
+        return formattingIsLegacy;
+    }
+
+    protected MineDownParser clickEvent(ClickEvent clickEvent) {
+        this.clickEvent = clickEvent;
+        return this;
+    }
+
+    protected ClickEvent clickEvent() {
+        return this.clickEvent;
+    }
+
+    protected MineDownParser hoverEvent(HoverEvent hoverEvent) {
+        this.hoverEvent = hoverEvent;
+        return this;
+    }
+
+    protected HoverEvent hoverEvent() {
+        return this.hoverEvent;
+    }
+
+    private static Integer parseRainbow(String colorString, String prefix, boolean lenient) {
+        if (colorString.substring(prefix.length()).toLowerCase(Locale.ROOT).startsWith(RAINBOW)) {
+            if (colorString.length() > prefix.length() + RAINBOW.length() + 1) {
+                try {
+                    return Integer.parseInt(colorString.substring(prefix.length() + RAINBOW.length() + 1));
+                } catch (NumberFormatException e) {
+                    if (!lenient) throw e;
+                }
+            } else {
+                return 0;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Parse a color/format definition
+     *
+     * @param colorString The string to parse
+     * @param prefix      The color prefix e.g. ampersand (&amp;)
+     * @param lenient     Whether or not to accept malformed strings
+     * @return The parsed color or <code>null</code> if lenient is true and no color was found
+     */
+    private static List<Map.Entry<Object, Boolean>> parseFormat(String colorString, String prefix, boolean lenient) {
+        List<Map.Entry<Object, Boolean>> formats = new ArrayList<>();
+        if (prefix.length() + 1 == colorString.length()) {
+            Object format = Util.getFormatFromLegacy(colorString.charAt(prefix.length()));
+            if (format == null && !lenient) {
+                throw new IllegalArgumentException(colorString.charAt(prefix.length()) + " is not a valid " + prefix + " char!");
+            }
+            formats.add(new AbstractMap.SimpleImmutableEntry<>(format, true));
+        } else {
+            for (String part : colorString.substring(prefix.length()).split("[\\-,]")) {
+                if (part.isEmpty()) {
+                    continue;
+                }
+                boolean negated = part.charAt(0) == '!';
+                if (negated) {
+                    part = part.substring(1);
+                }
+                try {
+                    TextFormat format = Util.getFormatFromString(part);
+                    if (format != null) {
+                        formats.add(new AbstractMap.SimpleImmutableEntry<>(format, !negated));
+                    }
+                } catch (IllegalArgumentException e) {
+                    if (!lenient) {
+                        throw e;
+                    }
+                }
+            }
+        }
+        return formats;
+    }
+
+    /**
+     * Parse a color/format definition
+     * @param shadowString The string to parse
+     * @param prefix       The shadow prefix
+     * @param lenient      Whether to accept malformed strings
+     * @return The parsed shadow color or <code>null</code> if lenient is true and no color was found
+     */
+    private static Object parseShadow(String shadowString, String prefix, boolean lenient) {
+        if (prefix.length() + 1 == shadowString.length()) {
+            Object format = Util.getFormatFromLegacy(shadowString.charAt(prefix.length()));
+            if (format == null && !lenient) {
+                throw new IllegalArgumentException(shadowString.charAt(prefix.length()) + " is not a valid " + prefix + " char!");
+            }
+            if (format instanceof TextColor) {
+                return AdventureCompat.shadowColor((TextColor) format, SHADOW_ALPHA);
+            } else if (!lenient) {
+                throw new IllegalArgumentException(shadowString.charAt(prefix.length()) + " is not a valid shadow color!");
+            } else {
+                return null;
+            }
+        }
+        String shadowColor = shadowString.substring(prefix.length());
+        if (shadowColor.isEmpty()) {
+            if (!lenient) {
+                throw new IllegalArgumentException("No value for the shadow specified!");
+            } else {
+                return null;
+            }
+        }
+
+        try {
+            TextFormat format = Util.getFormatFromString(shadowColor);
+            if (format instanceof TextColor) {
+                return AdventureCompat.shadowColor((TextColor) format, SHADOW_ALPHA);
+            } else if (format != null) {
+                if (!lenient) {
+                    throw new IllegalArgumentException(shadowColor + " is not a valid shadow color!");
+                }
+            }
+        } catch (IllegalArgumentException ignored) {}
+        String modShadowColor = shadowColor;
+        if (shadowColor.startsWith(HEX_PREFIX) && shadowColor.length() == 5) {
+            // support short form which only specifies a single hex for each channel
+            modShadowColor = HEX_PREFIX + shadowColor.charAt(1) + shadowColor.charAt(1)
+                    + shadowColor.charAt(2) + shadowColor.charAt(2)
+                    + shadowColor.charAt(3) + shadowColor.charAt(3)
+                    + shadowColor.charAt(4) + shadowColor.charAt(4);
+        }
+        Object shadow = AdventureCompat.shadowFromHexString(modShadowColor);
+        if (shadow != null) {
+            return shadow;
+        }
+        if (!lenient) {
+            throw new IllegalArgumentException(shadowColor + " is not a valid shadow color!");
+        }
+        return null;
+    }
+
+    /**
+     * Copy all the parser's setting to a new instance
+     * @return The new parser instance with all settings copied
+     */
+    public MineDownParser copy() {
+        return copy(false);
+    }
+
+    /**
+     * Copy all the parser's setting to a new instance
+     * @param formatting Should the formatting be copied too?
+     * @return The new parser instance with all settings copied
+     */
+    public MineDownParser copy(boolean formatting) {
+        return new MineDownParser().copy(this, formatting);
+    }
+
+    /**
+     * Copy all the parser's settings from another parser.
+     * @param from The parser to copy from
+     * @return This parser's instance
+     */
+    public MineDownParser copy(MineDownParser from) {
+        return copy(from, false);
+    }
+
+    /**
+     * Copy all the parser's settings from another parser.
+     * @param from       The parser to copy from
+     * @param formatting Should the formatting be copied too?
+     * @return This parser's instance
+     */
+    public MineDownParser copy(MineDownParser from, boolean formatting) {
+        lenient(from.lenient());
+        urlDetection(from.urlDetection());
+        urlHoverText(from.urlHoverText());
+        autoAddUrlPrefix(from.autoAddUrlPrefix());
+        hoverTextWidth(from.hoverTextWidth());
+        enabledOptions(from.enabledOptions());
+        filteredOptions(from.filteredOptions());
+        colorChar(from.colorChar());
+        if (formatting) {
+            format(from.format());
+            formattingIsLegacy(from.formattingIsLegacy());
+            rainbowPhase(from.rainbowPhase());
+            colors(from.colors());
+            colorsAreLegacy(from.colorsAreLegacy());
+            clickEvent(from.clickEvent());
+            hoverEvent(from.hoverEvent());
+        }
+        return this;
+    }
+
+    /**
+     * Reset the parser state to the start
+     * @return The parser's instance
+     */
+    public MineDownParser reset() {
+        builder = null;
+        value = new StringBuilder();
+        translationKey = null;
+        translationArgs.clear();
+        font = null;
+        insertion = null;
+        rainbowPhase = null;
+        colors = null;
+        colorsAreLegacy = false;
+        shadow = null;
+        format = new HashMap<>();
+        formattingIsLegacy = false;
+        clickEvent = null;
+        hoverEvent = null;
+        return this;
+    }
+
+    /**
+     * Whether or not to translate legacy color codes (Default: true)
+     * @return Whether or not to translate legacy color codes (Default: true)
+     * @deprecated Use {@link #isEnabled(Option)} instead
+     */
+    @Deprecated
+    public boolean translateLegacyColors() {
+        return isEnabled(Option.LEGACY_COLORS);
+    }
+
+    /**
+     * Whether or not to translate legacy color codes
+     * @return The parser
+     * @deprecated Use {@link #enable(Option)} and {@link #disable(Option)} instead
+     */
+    @Deprecated
+    public MineDownParser translateLegacyColors(boolean enabled) {
+        return enabled ? enable(Option.LEGACY_COLORS) : disable(Option.LEGACY_COLORS);
+    }
+
+    /**
+     * Check whether or not an option is enabled
+     * @param option The option to check for
+     * @return <code>true</code> if it's enabled; <code>false</code> if not
+     */
+    public boolean isEnabled(Option option) {
+        return enabledOptions().contains(option);
+    }
+
+    /**
+     * Enable an option.
+     * @param option The option to enable
+     * @return The parser instace
+     */
+    public MineDownParser enable(Option option) {
+        enabledOptions().add(option);
+        return this;
+    }
+
+    /**
+     * Disable an option. Disabling an option will stop the parser from replacing
+     * this option's chars in the string. Use {@link #filter(Option)} to completely
+     * remove the characters used by this option from the message instead.
+     * @param option The option to disable
+     * @return The parser instace
+     */
+    public MineDownParser disable(Option option) {
+        enabledOptions().remove(option);
+        return this;
+    }
+
+    /**
+     * Check whether or not an option is filtered
+     * @param option The option to check for
+     * @return <code>true</code> if it's enabled; <code>false</code> if not
+     */
+    public boolean isFiltered(Option option) {
+        return filteredOptions().contains(option);
+    }
+
+    /**
+     * Filter an option. This enables the parsing of an option and completely
+     * removes the characters of this option from the string.
+     * @param option The option to add to the filter
+     * @return The parser instance
+     */
+    public MineDownParser filter(Option option) {
+        filteredOptions().add(option);
+        enabledOptions().add(option);
+        return this;
+    }
+
+    /**
+     * Unfilter an option. Does not enable it!
+     * @param option The option to remove from the filter
+     * @return The parser instance
+     */
+    public MineDownParser unfilter(Option option) {
+        filteredOptions().remove(option);
+        return this;
+    }
+
+    /**
+     * Escape formatting in the string depending on this parser's options. This will escape backslashes too!
+     * @param string The string to escape
+     * @return The string with all formatting of this parser escaped
+     */
+    public String escape(String string) {
+        StringBuilder value = new StringBuilder();
+        for (int i = 0; i < string.length(); i++) {
+            char c = string.charAt(i);
+
+            boolean isEscape = c == '\\';
+            boolean isColorCode = isEnabled(Option.LEGACY_COLORS)
+                    && i + 1 < string.length() && (c == '§' || c == colorChar());
+            boolean isEvent = isEnabled(Option.ADVANCED_FORMATTING)
+                    && c == '[';
+            boolean isFormatting = isEnabled(Option.SIMPLE_FORMATTING)
+                    && (c == '_' || c == '*' || c == '~' || c == '?' || c == '#') && Util.isDouble(string, i);
+
+            if (isEscape || isColorCode || isEvent || isFormatting) {
+                value.append('\\');
+            }
+            value.append(c);
+        }
+        return value.toString();
+    }
+
+    public enum Option {
+        /**
+         * Translate simple, in-line MineDown formatting in strings? (Default: true)
+         */
+        SIMPLE_FORMATTING,
+        /**
+         * Translate advanced MineDown formatting (e.g. events) in strings? (Default: true)
+         */
+        ADVANCED_FORMATTING,
+        /**
+         * Whether or not to translate legacy color codes (Default: true)
+         */
+        LEGACY_COLORS
+    }
+
+    /**
+     * Get The character to use as a special color code.
+     * @return The color character (Default: ampersand &amp;)
+     */
+    public char colorChar() {
+        return this.colorChar;
+    }
+
+    /**
+     * Set the character to use as a special color code.
+     * @param colorChar The color char (Default: ampersand &amp;)
+     * @return The MineDownParser instance
+     */
+    public MineDownParser colorChar(char colorChar) {
+        this.colorChar = colorChar;
+        return this;
+    }
+
+    /**
+     * Get all enabled options that will be used when parsing
+     * @return a modifiable set of options
+     */
+    public Set<Option> enabledOptions() {
+        return this.enabledOptions;
+    }
+
+    /**
+     * Set all enabled options that will be used when parsing at once, replaces any existing options
+     * @param enabledOptions The enabled options
+     * @return The MineDownParser instance
+     */
+    public MineDownParser enabledOptions(Set<Option> enabledOptions) {
+        this.enabledOptions = enabledOptions;
+        return this;
+    }
+
+    /**
+     * Get all filtered options that will be parsed and then removed from the string
+     * @return a modifiable set of options
+     */
+    public Set<Option> filteredOptions() {
+        return this.filteredOptions;
+    }
+
+    /**
+     * Set all filtered options that will be parsed and then removed from the string at once,
+     * replaces any existing options
+     * @param filteredOptions The filtered options
+     * @return The MineDownParser instance
+     */
+    public MineDownParser filteredOptions(Set<Option> filteredOptions) {
+        this.filteredOptions = filteredOptions;
+        return this;
+    }
+
+    /**
+     * Get whether to accept malformed strings or not
+     * @return whether or not the accept malformed strings (Default: false)
+     */
+    public boolean lenient() {
+        return this.lenient;
+    }
+
+    /**
+     * Set whether to accept malformed strings or not
+     * @param lenient Set whether or not to accept malformed string (Default: false)
+     * @return The MineDownParser instance
+     */
+    public MineDownParser lenient(boolean lenient) {
+        this.lenient = lenient;
+        return this;
+    }
+
+    /**
+     * Get whether or not urls in strings are detected and get events added to them?
+     * @return whether or not urls are detected (Default: true)
+     */
+    public boolean urlDetection() {
+        return this.urlDetection;
+    }
+
+    /**
+     * Set whether or not to detect urls in strings and add events to them?
+     * @param urlDetection Whether or not to detect urls in strings  (Default: true)
+     * @return The MineDownParser instance
+     */
+    public MineDownParser urlDetection(boolean urlDetection) {
+        this.urlDetection = urlDetection;
+        return this;
+    }
+
+    /**
+     * Get the text to display when hovering over an URL. Has a %url% placeholder.
+     */
+    public String urlHoverText() {
+        return this.urlHoverText;
+    }
+
+    /**
+     * Set the text to display when hovering over an URL. Has a %url% placeholder.
+     * @param urlHoverText The url hover text
+     * @return The MineDownParser instance
+     */
+    public MineDownParser urlHoverText(String urlHoverText) {
+        this.urlHoverText = urlHoverText;
+        return this;
+    }
+
+    /**
+     * Get whether or not to automatically add http to values of open_url when there doesn't exist any?
+     * @return whether or not to automatically add http to values of open_url when there doesn't exist any? (Default: true)
+     */
+    public boolean autoAddUrlPrefix() {
+        return this.autoAddUrlPrefix;
+    }
+
+    /**
+     * Set whether or not to automatically add http to values of open_url when there doesn't exist any?
+     * @param autoAddUrlPrefix Whether or not automatically add http to values of open_url when there doesn't exist any? (Default: true)
+     * @return The MineDownParser instance
+     */
+    public MineDownParser autoAddUrlPrefix(boolean autoAddUrlPrefix) {
+        this.autoAddUrlPrefix = autoAddUrlPrefix;
+        return this;
+    }
+
+    /**
+     * Get the max width the hover text should have.
+     * Minecraft itself will wrap after 60 characters.
+     * Won't apply if the text already includes new lines.
+     */
+    public int hoverTextWidth() {
+        return this.hoverTextWidth;
+    }
+
+    /**
+     * Set the max width the hover text should have.
+     * Minecraft itself will wrap after 60 characters.
+     * Won't apply if the text already includes new lines.
+     * @param hoverTextWidth The url hover text length
+     * @return The MineDownParser instance
+     */
+    public MineDownParser hoverTextWidth(int hoverTextWidth) {
+        this.hoverTextWidth = hoverTextWidth;
+        return this;
+    }
+
+}

--- a/common/src/main/java/de/themoep/minedown/adventure/Replacer.java
+++ b/common/src/main/java/de/themoep/minedown/adventure/Replacer.java
@@ -1,0 +1,485 @@
+package de.themoep.minedown.adventure;
+
+/*
+ * Copyright (c) 2020 Max Lee (https://github.com/Phoenix616)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.nbt.api.BinaryTagHolder;
+import net.kyori.adventure.text.BuildableComponent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentBuilder;
+import net.kyori.adventure.text.KeybindComponent;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.TranslatableComponent;
+import net.kyori.adventure.text.TranslationArgumentLike;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * This class offers the ability to replace placeholders with values in strings and components.
+ * It also lets you define which placeholders indicators (prefix and suffix) should be used.
+ * By default these are the % character.
+ */
+public class Replacer {
+
+    /**
+     * A cache of compiled replacement patterns
+     */
+    private static final Map<String, Pattern> PATTERN_CACHE = new ConcurrentHashMap<>();
+
+    /**
+     * The creator of the patterns for the pattern cache
+     */
+    private static final Function<String, Pattern> PATTERN_CREATOR = p -> Pattern.compile(p, Pattern.LITERAL);
+
+    /**
+     * The map of placeholders with their string replacements
+     */
+    private final Map<String, String> replacements = new LinkedHashMap<>();
+
+    /**
+     * The map of placeholders with their component array replacements
+     */
+    private final Map<String, Component> componentReplacements = new LinkedHashMap<>();
+
+    /**
+     * The placeholder indicator's prefix character
+     */
+    private String placeholderPrefix = "%";
+
+    /**
+     * The placeholder indicator's suffix character
+     */
+    private String placeholderSuffix = "%";
+
+    /**
+     * Replace the placeholder no matter what the case of it is
+     */
+    private boolean ignorePlaceholderCase = true;
+
+    /**
+     * Replace certain placeholders with values in string.
+     * This uses the % character as placeholder indicators (suffix and prefix)
+     * @param message      The string to replace in
+     * @param replacements The replacements, nth element is the placeholder, n+1th the value
+     * @return The string with all the placeholders replaced
+     */
+    @Contract("null, _ -> null")
+    public static @Nullable String replaceIn(@Nullable String message, String... replacements) {
+        return new Replacer().replace(replacements).replaceStrings(message);
+    }
+
+    /**
+     * Replace certain placeholders with values in a component array.
+     * This uses the % character as placeholder indicators (suffix and prefix)
+     * @param message      The Component to replace in
+     * @param replacements The replacements, nth element is the placeholder, n+1th the value
+     * @return A copy of the Component array with all the placeholders replaced
+     */
+    @Contract("null, _ -> null")
+    public static @Nullable Component replaceIn(@Nullable Component message, String... replacements) {
+        return new Replacer().replace(replacements).replaceIn(message);
+    }
+
+    /**
+     * Replace a certain placeholder with a component array in a component array.
+     * This uses the % character as placeholder indicators (suffix and prefix)
+     * @param message     The Component to replace in
+     * @param placeholder The placeholder to replace
+     * @param replacement The replacement components
+     * @return A copy of the Component array with all the placeholders replaced
+     */
+    @Contract("null, _, _ -> null")
+    public static @Nullable Component replaceIn(@Nullable Component message, String placeholder, Component replacement) {
+        return new Replacer().replace(placeholder, replacement).replaceIn(message);
+    }
+
+    /**
+     * Add an array with placeholders and values that should get replaced in the message
+     * @param replacements The replacements, nth element is the placeholder, n+1th the value
+     * @return The Replacer instance
+     */
+    public Replacer replace(String... replacements) {
+        Util.validate(replacements.length % 2 == 0, "The replacement length has to be even, " +
+                "mapping i % 2 == 0 to the placeholder and i % 2 = 1 to the placeholder's value");
+        Map<String, String> replacementMap = new LinkedHashMap<>();
+        for (int i = 0; i + 1 < replacements.length; i += 2) {
+            replacementMap.put(replacements[i], replacements[i + 1]);
+        }
+        return replace(replacementMap);
+    }
+
+    /**
+     * Add a map with placeholders and values that should get replaced in the message
+     * @param replacements The replacements mapped placeholder to value
+     * @return The Replacer instance
+     */
+    public Replacer replace(Map<String, ?> replacements) {
+        if (replacements != null && !replacements.isEmpty()) {
+            Object any = replacements.values().stream().filter(Objects::nonNull).findAny().orElse(null);
+            if (any instanceof String) {
+                replacements().putAll((Map<String, String>) replacements);
+            } else if (any instanceof Component) {
+                componentReplacements().putAll((Map<String, Component>) replacements);
+            } else {
+                for (Map.Entry<String, ?> entry : replacements.entrySet()) {
+                    replacements().put(entry.getKey(), String.valueOf(entry.getValue()));
+                }
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Add a placeholder to component mapping that should get replaced in the message
+     * @param placeholder The placeholder to replace
+     * @param replacement The replacement components
+     * @return The Replacer instance
+     */
+    public Replacer replace(String placeholder, Component replacement) {
+        componentReplacements().put(placeholder, replacement);
+        return this;
+    }
+
+    /**
+     * Set the placeholder indicator for both prefix and suffix
+     * @param placeholderIndicator The character to use as a placeholder indicator
+     * @return The Replacer instance
+     */
+    public Replacer placeholderIndicator(String placeholderIndicator) {
+        placeholderPrefix(placeholderIndicator);
+        placeholderSuffix(placeholderIndicator);
+        return this;
+    }
+
+    /**
+     * Replace the placeholders in a component list
+     * @param components The Component list to replace in
+     * @return A copy of the array with the placeholders replaced
+     */
+    @Contract("null -> null")
+    public @Nullable List<@Nullable Component> replaceIn(@Nullable List<@Nullable Component> components) {
+        if (components == null) {
+            return null;
+        }
+
+        List<Component> replaced = new ArrayList<>();
+        for (Component component : components) {
+            replaced.add(replaceIn(component));
+        }
+        return replaced;
+    }
+
+    /**
+     * Replace the placeholders in a component list
+     * @param component The Component list to replace in
+     * @return A copy of the array with the placeholders replaced
+     */
+    @Contract("null -> null")
+    public @Nullable Component replaceIn(@Nullable Component component) {
+        if (component == null) {
+            return null;
+        }
+
+        TextComponent.Builder builder = Component.text();
+
+        if (component instanceof KeybindComponent) {
+            component = ((KeybindComponent) component).keybind(replaceIn(((KeybindComponent) component).keybind()));
+        }
+        if (component instanceof TextComponent) {
+            String replaced = replaceStrings(((TextComponent) component).content());
+            int sectionIndex = replaced.indexOf('§');
+            if (sectionIndex > -1 && replaced.length() > sectionIndex + 1
+                    && Util.getFormatFromLegacy(replaced.toLowerCase(Locale.ROOT).charAt(sectionIndex + 1)) != null) {
+                // replacement contain legacy code, parse to components and append them as children
+                Component replacedComponent = LegacyComponentSerializer.legacySection().deserialize(replaced);
+                component = ((TextComponent) component).content("");
+                List<Component> children = new ArrayList<>();
+                children.add(replacedComponent);
+                children.addAll(replaceIn(component.children()));
+                component = component.children(children);
+            } else {
+                component = ((TextComponent) component).content(replaced).children(replaceIn(component.children()));
+            }
+        } else if (!component.children().isEmpty()) {
+            component = component.children(replaceIn(component.children()));
+        }
+        if (component instanceof TranslatableComponent) {
+            component = ((TranslatableComponent) component).key(replaceIn(((TranslatableComponent) component).key()));
+            component = ((TranslatableComponent) component).arguments(replaceIn(((TranslatableComponent) component).arguments().stream()
+                    .map(TranslationArgumentLike::asComponent).collect(Collectors.toList())));
+        }
+        if (component.insertion() != null) {
+            component = component.insertion(replaceIn(component.insertion()));
+        }
+        if (component.clickEvent() != null) {
+            final ClickEvent clickEvent = component.clickEvent();
+            final String value = Util.clickEventValue(clickEvent);
+            if (value != null) {
+                final BinaryTagHolder tag = Util.clickEventPayloadTag(clickEvent);
+                final String replacedValue = replaceIn(value);
+                final BinaryTagHolder replacedTag = tag != null
+                        ? BinaryTagHolder.binaryTagHolder(replaceIn(tag.string())) : null;
+                if (!value.equals(replacedValue) || (tag != null && !tag.string().equals(replacedTag.string()))) {
+                    try {
+                        component = component.clickEvent(
+                                Util.createClickEvent(clickEvent.action(), replacedValue, replacedTag)
+                        );
+                    } catch (IllegalArgumentException ignored) {
+                        // Keep the original click event if the replaced value isn't valid for its action
+                    }
+                }
+            }
+        }
+        if (component.hoverEvent() != null) {
+            if (component.hoverEvent().action() == HoverEvent.Action.SHOW_TEXT) {
+                component = component.hoverEvent(HoverEvent.showText(
+                        replaceIn((Component) component.hoverEvent().value())
+                ));
+            } else if (component.hoverEvent().action() == HoverEvent.Action.SHOW_ENTITY) {
+                HoverEvent.ShowEntity showEntity = (HoverEvent.ShowEntity) component.hoverEvent().value();
+                component = component.hoverEvent(HoverEvent.showEntity(
+                        HoverEvent.ShowEntity.showEntity(
+                                Key.key(replaceIn(showEntity.type().asString())),
+                                showEntity.id(),
+                                replaceIn(showEntity.name())
+                        )
+                ));
+            } else if (component.hoverEvent().action() == HoverEvent.Action.SHOW_ITEM) {
+                HoverEvent.ShowItem showItem = (HoverEvent.ShowItem) component.hoverEvent().value();
+                component = component.hoverEvent(HoverEvent.showItem(
+                        HoverEvent.ShowItem.showItem(
+                                Key.key(replaceIn(showItem.item().asString())),
+                                showItem.count(),
+                                showItem.nbt() != null ? BinaryTagHolder.binaryTagHolder(replaceIn(showItem.nbt().string())) : null
+                        )
+                ));
+            }
+        }
+
+        // Component replacements
+        List<Component> replacedComponents = new ArrayList<>();
+        replacedComponents.add(component);
+
+        for (Map.Entry<String, Component> replacement : componentReplacements().entrySet()) {
+            List<Component> newReplacedComponents = new ArrayList<>();
+
+            for (Component replaceComponent : replacedComponents) {
+                if (replaceComponent instanceof TextComponent) {
+                    TextComponent textComponent = (TextComponent) replaceComponent;
+                    String placeHolder = placeholderPrefix()
+                            + (ignorePlaceholderCase() ? replacement.getKey().toLowerCase(Locale.ROOT) : replacement.getKey())
+                            + placeholderSuffix();
+                    String text = ignorePlaceholderCase() ? textComponent.content().toLowerCase(Locale.ROOT) : textComponent.content();
+                    int index = text.indexOf(placeHolder);
+                    if (index > -1) {
+                        while (true) {
+                            ComponentBuilder<?, ?> startBuilder;
+                            if (index > 0) {
+                                startBuilder = Component.text().mergeStyle(textComponent);
+                                ((TextComponent.Builder) startBuilder).content(textComponent.content().substring(0, index));
+                                startBuilder.append(replacement.getValue());
+                            } else if (replacement.getValue() instanceof BuildableComponent){
+                                startBuilder = ((BuildableComponent<?, ?>) replacement.getValue()).toBuilder();
+                                // Merge replacement style onto the component's to properly apply the replacement styles over the component ones
+                                startBuilder.style(Style.style().merge(textComponent.style()).merge(replacement.getValue().style()).build());
+                            } else {
+                                startBuilder = Component.text().mergeStyle(textComponent);
+                                startBuilder.append(replacement.getValue());
+                            }
+                            newReplacedComponents.add(startBuilder.build());
+
+                            textComponent = textComponent.content(textComponent.content().substring(index + placeHolder.length()));
+                            text = ignorePlaceholderCase() ? textComponent.content().toLowerCase(Locale.ROOT) : textComponent.content();
+
+                            if (text.isEmpty() || (index = text.indexOf(placeHolder)) < 0) {
+                                // No further placeholder in text, add rest to newReplacedComponents
+                                newReplacedComponents.add(textComponent);
+                                break;
+                            }
+                        }
+                        continue;
+                    }
+                }
+
+                // Nothing was replaced, just add it
+                newReplacedComponents.add(replaceComponent);
+            }
+            replacedComponents = newReplacedComponents;
+        }
+        builder.append(replacedComponents);
+
+        return builder.build().compact();
+    }
+
+    /**
+     * Replace the placeholders in a string.
+     * @param string The String list to replace in
+     * @return The string with the placeholders replaced
+     */
+    @Contract("null -> null")
+    public @Nullable String replaceIn(@Nullable String string) {
+        if (string == null) {
+            return null;
+        }
+
+        Replacer replacer = copy();
+        for (Map.Entry<String, Component> entry : replacer.componentReplacements().entrySet()) {
+            replacer.replacements().putIfAbsent(entry.getKey(), LegacyComponentSerializer.legacySection().serialize(entry.getValue()));
+        }
+        return replacer.replaceStrings(string);
+    }
+
+    /**
+     * Replace the placeholders in a string. Does not replace component replacements!
+     * @param string The String list to replace in
+     * @return The string with the placeholders replaced
+     */
+    String replaceStrings(String string) {
+        for (Map.Entry<String, String> replacement : replacements().entrySet()) {
+            String replValue = replacement.getValue() != null ? replacement.getValue() : "null";
+            if (ignorePlaceholderCase()) {
+                String placeholder = placeholderPrefix() + replacement.getKey().toLowerCase(Locale.ROOT) + placeholderSuffix();
+                int nextStart = 0;
+                int startIndex;
+                while (nextStart < string.length() && (startIndex = string.toLowerCase(Locale.ROOT).indexOf(placeholder, nextStart)) > -1) {
+                    nextStart = startIndex + replValue.length();
+                    string = string.substring(0, startIndex) + replValue + string.substring(startIndex + placeholder.length());
+                }
+            } else {
+                String placeholder = placeholderPrefix() + replacement.getKey() + placeholderSuffix();
+                Pattern pattern = PATTERN_CACHE.computeIfAbsent(placeholder, PATTERN_CREATOR);
+                string = pattern.matcher(string).replaceAll(Matcher.quoteReplacement(replValue));
+            }
+        }
+        return string;
+    }
+
+    /**
+     * Create a copy of this Replacer
+     * @return A copy of this Replacer
+     */
+    public Replacer copy() {
+        return new Replacer().copy(this);
+    }
+
+    /**
+     * Copy all the values of another Replacer
+     * @param from The replacer to copy
+     * @return The Replacer instance
+     */
+    public Replacer copy(Replacer from) {
+        replacements().clear();
+        replacements().putAll(from.replacements());
+        componentReplacements().clear();
+        componentReplacements().putAll(from.componentReplacements());
+        placeholderPrefix(from.placeholderPrefix());
+        placeholderSuffix(from.placeholderSuffix());
+        return this;
+    }
+
+    /**
+     * Get the map of placeholders with their string replacements
+     * @return the replacement map
+     */
+    public Map<String, String> replacements() {
+        return this.replacements;
+    }
+
+    /**
+     * Get the map of placeholders with their component array replacements
+     * @return the replacement map
+     */
+    public Map<String, Component> componentReplacements() {
+        return this.componentReplacements;
+    }
+
+    /**
+     * Get the placeholder indicator's prefix string
+     * @return the prefix characters
+     */
+    public String placeholderPrefix() {
+        return this.placeholderPrefix;
+    }
+
+    /**
+     * Set the placeholder indicator's prefix string
+     * @param placeholderPrefix The placeholder prefix string
+     * @return the instance of this Replacer
+     */
+    public Replacer placeholderPrefix(String placeholderPrefix) {
+        this.placeholderPrefix = placeholderPrefix;
+        return this;
+    }
+
+    /**
+     * Get the placeholder indicator's suffix string
+     * @return the suffix characters
+     */
+    public String placeholderSuffix() {
+        return this.placeholderSuffix;
+    }
+
+    /**
+     * Set the placeholder indicator's suffix string
+     * @param placeholderSuffix The placeholder suffix string
+     * @return the instance of this Replacer
+     */
+    public Replacer placeholderSuffix(String placeholderSuffix) {
+        this.placeholderSuffix = placeholderSuffix;
+        return this;
+    }
+
+    /**
+     * Replace the placeholder no matter what the case of it is
+     * @return whether or not to ignore the placeholder case (Default: true)
+     */
+    public boolean ignorePlaceholderCase() {
+        return this.ignorePlaceholderCase;
+    }
+
+    /**
+     * Set whether or not the placeholder should be replaced no matter what the case of it is
+     * @param ignorePlaceholderCase Whether or not to ignore the case in placeholders (Default: true)
+     * @return the instance of this Replacer
+     */
+    public Replacer ignorePlaceholderCase(boolean ignorePlaceholderCase) {
+        this.ignorePlaceholderCase = ignorePlaceholderCase;
+        return this;
+    }
+}

--- a/common/src/main/java/de/themoep/minedown/adventure/Util.java
+++ b/common/src/main/java/de/themoep/minedown/adventure/Util.java
@@ -1,0 +1,732 @@
+package de.themoep.minedown.adventure;
+
+/*
+ * Copyright (c) 2020 Max Lee (https://github.com/Phoenix616)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.nbt.api.BinaryTagHolder;
+import net.kyori.adventure.text.BuildableComponent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentBuilder;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.format.TextFormat;
+
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class Util {
+
+    private static final Pattern WRAP_PATTERN = Pattern.compile(" ", Pattern.LITERAL);
+
+    /**
+     * Utility method to throw an IllegalArgumentException if the value is false
+     * @param value   The value to validate
+     * @param message The message for the exception
+     * @throws IllegalArgumentException Thrown if the value is false
+     */
+    public static void validate(boolean value, String message) throws IllegalArgumentException {
+        if (!value) {
+            throw new IllegalArgumentException(message);
+        }
+    }
+
+    /**
+     * Apply a collection of colors/formats to a component
+     * @param component The BaseComponent
+     * @param formats   The collection of TextColor formats to apply
+     * @return The component that was modified
+     */
+    public static Component applyFormat(Component component, Collection<TextDecoration> formats) {
+        for (TextDecoration format : formats) {
+            component.decoration(format, true);
+        }
+        if (!component.children().isEmpty()) {
+            for (Component extra : component.children()) {
+                applyFormat(extra, formats);
+            }
+        }
+        return component;
+    }
+
+    /**
+     * Apply a collection of colors/formats to a component builder
+     * @param builder The ComponentBuilder
+     * @param formats The collection of TextColor formats to apply
+     * @return The component builder that was modified
+     * @deprecated Use {@link #applyFormat(ComponentBuilder, Map)}
+     */
+    @Deprecated
+    public static ComponentBuilder applyFormat(ComponentBuilder builder, Collection<TextDecoration> formats) {
+        for (TextDecoration format : formats) {
+            builder.decoration(format, true);
+        }
+        return builder;
+    }
+
+    /**
+     * Apply a collection of colors/formats to a component builder
+     * @param builder The ComponentBuilder
+     * @param formats The collection of TextColor formats to apply
+     * @return The component builder that was modified
+     */
+    public static ComponentBuilder applyFormat(ComponentBuilder builder, Map<TextDecoration, Boolean> formats) {
+        for (Map.Entry<TextDecoration, Boolean> e : formats.entrySet()) {
+            builder.decoration(e.getKey(), e.getValue());
+        }
+        return builder;
+    }
+
+    /**
+     * Check whether or not a character at a certain index of a string repeats itself
+     * @param string The string to check
+     * @param index  The index at which to check the character
+     * @return Whether or not the character at that index repeated itself
+     */
+    public static boolean isDouble(String string, int index) {
+        return index + 1 < string.length() && string.charAt(index) == string.charAt(index + 1);
+    }
+
+    /**
+     * Check whether a certain TextColor is formatting or not
+     * @param format The TextColor to check
+     * @return <code>true</code> if it's a format, <code>false</code> if it's a color
+     */
+    public static boolean isFormat(TextColor format) {
+        return false;
+    }
+
+    /**
+     * Get a set of TextColor formats all formats that a component includes
+     * @param component    The component to get the formats from
+     * @param ignoreParent Whether or not to include the parent's format (TODO: Does kyori-text not handle this?)
+     * @return A set of all the format TextColors that the component includes
+     */
+    public static Set<TextDecoration> getFormats(Component component, boolean ignoreParent) {
+        return component.decorations().entrySet().stream()
+                .filter(e -> e.getValue() == TextDecoration.State.TRUE)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Get the index of the first occurrences of a not escaped character
+     * @param string The string to search
+     * @param chars  The characters to search for
+     * @return The first unescaped index or -1 if not found
+     */
+    public static int indexOfNotEscaped(String string, String chars) {
+        return indexOfNotEscaped(string, chars, 0);
+    }
+
+    /**
+     * Get the index of the first occurrences of a not escaped character
+     * @param string    The string to search
+     * @param chars     The characters to search for
+     * @param fromIndex Start searching from that index
+     * @return The first unescaped index or {@code -1} if not found
+     */
+    public static int indexOfNotEscaped(String string, String chars, int fromIndex) {
+        for (int i = fromIndex; i < string.length(); i++) {
+            int index = string.indexOf(chars, i);
+            if (index == -1) {
+                return -1;
+            }
+            if (!isEscaped(string, index)) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Check if a character at a certain index is escaped
+     * @param string The string to check
+     * @param index  The index of the character in the string to check
+     * @return Whether or not the character is escaped (uneven number of backslashes in front of char mains it is escaped)
+     * @throws IndexOutOfBoundsException if the {@code index} argument is not less than the length of this string.
+     */
+    public static boolean isEscaped(String string, int index) {
+        if (index - 1 > string.length()) {
+            return false;
+        }
+        int e = 0;
+        while (index > e && string.charAt(index - e - 1) == '\\') {
+            e++;
+        }
+        return e % 2 != 0;
+    }
+
+    /**
+     * Gets the proper end index of a certain definition on the same depth while ignoring escaped chars.
+     * @param string    The string to search
+     * @param startChar The start cahracter of the definition
+     * @param endChar   The end character of the definition
+     * @param fromIndex The index to start searching from (should be at the start char)
+     * @return The first end index of that group  or {@code -1} if not found
+     */
+    public static int getUnescapedEndIndex(String string, char startChar, char endChar, int fromIndex) {
+        int depth = 0;
+        boolean innerEscaped = false;
+        for (int i = fromIndex; i < string.length(); i++) {
+            if (innerEscaped) {
+                innerEscaped = false;
+            } else if (string.charAt(i) == '\\') {
+                innerEscaped = true;
+            } else if (string.charAt(i) == startChar) {
+                depth++;
+            } else if (string.charAt(i) == endChar) {
+                depth--;
+                if (depth == 0) {
+                    return i;
+                }
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Wrap a string if it is longer than the line length and contains no new line.
+     * Will try to wrap at spaces between words.
+     * @param string        The string to wrap
+     * @param lineLength    The max length of a line
+     * @return The wrapped string
+     */
+    public static String wrap(String string, int lineLength) {
+        if (string.length() <= lineLength || string.contains("\n")) {
+            return string;
+        }
+
+        List<String> lines = new ArrayList<>();
+        StringBuilder currentLine = new StringBuilder();
+        for (String s : WRAP_PATTERN.split(string)) {
+            if (currentLine.length() + s.length() + 1 > lineLength) {
+                int rest = lineLength - currentLine.length() - 1;
+                if (rest > lineLength / 4 && s.length() > Math.min(rest * 2, lineLength / 4)) {
+                    currentLine.append(" ").append(s, 0, rest);
+                } else {
+                    rest = 0;
+                }
+                lines.add(currentLine.toString());
+                String restString = s.substring(rest);
+                while (restString.length() >= lineLength) {
+                    lines.add(restString.substring(0, lineLength));
+                    restString = restString.substring(lineLength);
+                }
+                currentLine = new StringBuilder(restString);
+            } else {
+                if (currentLine.length() > 0) {
+                    currentLine.append(" ");
+                }
+                currentLine.append(s);
+            }
+        }
+        if (currentLine.length() > 0) {
+            lines.add(currentLine.toString());
+        }
+        return String.join("\n", lines);
+    }
+
+    /**
+     * Utility method to remove RGB colors from components. This modifies the input array!
+     * @param components    The components to remove the rgb colors from
+     * @return The modified components (same as input).
+     */
+    public static Component rgbColorsToLegacy(Component components) {
+        return Component.text().append(components).mapChildrenDeep(buildableComponent
+                -> buildableComponent.color() != null
+                        ? (BuildableComponent) buildableComponent.color(NamedTextColor.nearestTo(buildableComponent.color()))
+                        : buildableComponent
+        ).build();
+    }
+
+    /**
+     * Get the legacy color closest to a certain RGB color
+     * @param textColor The color to get the closest legacy color for
+     * @return The closest legacy color
+     * @deprecated Use {@link NamedTextColor#nearestTo(TextColor)}
+     */
+    @Deprecated
+    public static NamedTextColor getClosestLegacy(TextColor textColor) {
+        return textColor != null ? NamedTextColor.nearestTo(textColor) : null;
+    }
+
+    /**
+     * Get the distance between two colors
+     * @param c1 Color A
+     * @param c2 Color B
+     * @return The distance or 0 if they are equal
+     * @deprecated Doesn't use perceived brightness (HSV) but simply takes the distance between RGB. Do not rely on this, I twill look ugly!
+     */
+    @Deprecated
+    public static double distance(Color c1, Color c2) {
+        if (c1.getRGB() == c2.getRGB()) {
+            return 0;
+        }
+        return Math.sqrt(Math.pow(c1.getRed() - c2.getRed(), 2) + Math.pow(c1.getGreen() - c2.getGreen(), 2) + Math.pow(c1.getBlue() - c2.getBlue(), 2));
+    }
+
+    /**
+     * Get the text format from a string, either its name or hex code
+     * @param formatString The string to get the format from
+     * @return The TextFormat
+     * @throws IllegalArgumentException if the format could not be found from the string
+     */
+    public static TextFormat getFormatFromString(String formatString) throws IllegalArgumentException {
+        TextFormat format;
+        if (formatString.charAt(0) == '#') {
+            format = TextColor.fromCSSHexString(formatString);
+        } else {
+            format = NamedTextColor.NAMES.value(formatString.toLowerCase(Locale.ROOT));
+            if (format == null) {
+                format = TextDecoration.NAMES.value(formatString.toLowerCase(Locale.ROOT));
+            }
+            if (format == null) {
+                // Handle legacy formatting names
+                switch (formatString.toLowerCase(Locale.ROOT)) {
+                    case "underline":
+                        return TextDecoration.UNDERLINED;
+                    case "magic":
+                        return TextDecoration.OBFUSCATED;
+                }
+            }
+        }
+
+        if (format != null) {
+            return format;
+        }
+        throw new IllegalArgumentException("Unknown format: " + formatString);
+    }
+
+    /**
+     * Get a TextFormat from its legacy color code as kyori-text-api does not support that
+     * @param code  The legacy char
+     * @return      The TextFormat or null if none found with that char
+     */
+    public static Object getFormatFromLegacy(char code) {
+        switch (code) {
+            case '0': return NamedTextColor.BLACK;
+            case '1': return NamedTextColor.DARK_BLUE;
+            case '2': return NamedTextColor.DARK_GREEN;
+            case '3': return NamedTextColor.DARK_AQUA;
+            case '4': return NamedTextColor.DARK_RED;
+            case '5': return NamedTextColor.DARK_PURPLE;
+            case '6': return NamedTextColor.GOLD;
+            case '7': return NamedTextColor.GRAY;
+            case '8': return NamedTextColor.DARK_GRAY;
+            case '9': return NamedTextColor.BLUE;
+            case 'a': return NamedTextColor.GREEN;
+            case 'b': return NamedTextColor.AQUA;
+            case 'c': return NamedTextColor.RED;
+            case 'd': return NamedTextColor.LIGHT_PURPLE;
+            case 'e': return NamedTextColor.YELLOW;
+            case 'f': return NamedTextColor.WHITE;
+            case 'k': return TextDecoration.OBFUSCATED;
+            case 'l': return TextDecoration.BOLD;
+            case 'm': return TextDecoration.STRIKETHROUGH;
+            case 'n': return TextDecoration.UNDERLINED;
+            case 'o': return TextDecoration.ITALIC;
+            case 'r': return TextControl.RESET;
+        }
+        return null;
+    }
+
+    /**
+     * Get the legacy color code from its format as kyori-text-api does not support that
+     * @param format    The format
+     * @return          The legacy color code or null if none found with that char
+     */
+    public static char getLegacyFormatChar(Object format) {
+        if (format == TextControl.RESET) {
+            return 'r';
+        } else if (format instanceof NamedTextColor) {
+                if (format == NamedTextColor.BLACK) return '0';
+                if (format == NamedTextColor.DARK_BLUE) return '1';
+                if (format == NamedTextColor.DARK_GREEN) return '2';
+                if (format == NamedTextColor.DARK_AQUA) return '3';
+                if (format == NamedTextColor.DARK_RED) return '4';
+                if (format == NamedTextColor.DARK_PURPLE) return '5';
+                if (format == NamedTextColor.GOLD) return '6';
+                if (format == NamedTextColor.GRAY) return '7';
+                if (format == NamedTextColor.DARK_GRAY) return '8';
+                if (format == NamedTextColor.BLUE) return '9';
+                if (format == NamedTextColor.GREEN) return 'a';
+                if (format == NamedTextColor.AQUA) return 'b';
+                if (format == NamedTextColor.RED) return 'c';
+                if (format == NamedTextColor.LIGHT_PURPLE) return 'd';
+                if (format == NamedTextColor.YELLOW) return 'e';
+                if (format == NamedTextColor.WHITE) return 'f';
+        } else if (format instanceof TextDecoration) {
+            switch ((TextDecoration) format) {
+                case OBFUSCATED: return 'k';
+                case BOLD: return 'l';
+                case STRIKETHROUGH: return 'm';
+                case UNDERLINED: return 'n';
+                case ITALIC: return 'o';
+            }
+        } else if (format instanceof TextColor) {
+            return getLegacyFormatChar(NamedTextColor.nearestTo((TextColor) format));
+        }
+        throw new IllegalArgumentException(format + " is not supported!");
+    }    /*
+     * createRainbow is adapted from the net.kyori.adventure.text.minimessage.fancy.Rainbow class
+     * in adventure-text-minimessage, licensed under the MIT License.
+     *
+     * Copyright (c) 2018-2020 KyoriPowered
+     *
+     * Permission is hereby granted, free of charge, to any person obtaining a copy
+     * of this software and associated documentation files (the "Software"), to deal
+     * in the Software without restriction, including without limitation the rights
+     * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+     * copies of the Software, and to permit persons to whom the Software is
+     * furnished to do so, subject to the following conditions:
+     *
+     * The above copyright notice and this permission notice shall be included in all
+     * copies or substantial portions of the Software.
+     *
+     * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+     * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+     * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+     * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+     * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+     * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+     * SOFTWARE.
+     */
+    /**
+     * Generate a rainbow with a certain length and phase
+     * @param length    The length of the rainbow
+     * @param phase     The phase of the rainbow.
+     * @return the colors in the rainbow
+     * @deprecated Use {@link #createRainbow(long, int)}
+     */
+    @Deprecated
+    public static List<TextColor> createRainbow(int length, int phase) {
+        return createRainbow((long) length, phase);
+    }
+
+    /**
+     * Generate a rainbow with a certain length and phase
+     * @param length    The length of the rainbow
+     * @param phase     The phase of the rainbow.
+     * @return the colors in the rainbow
+     */
+    public static List<TextColor> createRainbow(long length, int phase) {
+        List<TextColor> colors = new ArrayList<>();
+
+        float fPhase = phase / 10f;
+
+        float center = 128;
+        float width = 127;
+        double frequency = Math.PI * 2 / length;
+
+        for (long i = 0; i < length; i++) {
+            colors.add(TextColor.color(
+                    (int) (Math.sin(frequency * i + 2 + fPhase) * width + center),
+                    (int) (Math.sin(frequency * i + 0 + fPhase) * width + center),
+                    (int) (Math.sin(frequency * i + 4 + fPhase) * width + center)
+            ));
+    }
+        return colors;
+    }
+
+    /*
+     * createGradient is adapted from the net.kyori.adventure.text.minimessage.fancy.Gradient class
+     * in adventure-text-minimessage, licensed under the MIT License.
+     *
+     * Copyright (c) 2018-2020 KyoriPowered
+     *
+     * Permission is hereby granted, free of charge, to any person obtaining a copy
+     * of this software and associated documentation files (the "Software"), to deal
+     * in the Software without restriction, including without limitation the rights
+     * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+     * copies of the Software, and to permit persons to whom the Software is
+     * furnished to do so, subject to the following conditions:
+     *
+     * The above copyright notice and this permission notice shall be included in all
+     * copies or substantial portions of the Software.
+     *
+     * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+     * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+     * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+     * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+     * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+     * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+     * SOFTWARE.
+     */
+    /**
+     * Generate a gradient with certain colors
+     * @param length    The length of the gradient
+     * @param gradient    The colors of the gradient.
+     * @return the colors in the gradient
+     * @deprecated Use {@link #createGradient(long, List)}
+     */
+    @Deprecated
+    public static List<TextColor> createGradient(int length, List<TextColor> gradient) {
+        return createGradient((long) length, gradient);
+    }
+
+    /**
+     * Generate a gradient with certain colors
+     * @param length    The length of the gradient
+     * @param gradient    The colors of the gradient.
+     * @return the colors in the gradient
+     */
+    public static List<TextColor> createGradient(long length, List<TextColor> gradient) {
+        List<TextColor> colors = new ArrayList<>();
+        if (gradient.size() < 2 || length < 2) {
+            if (gradient.isEmpty()) {
+                return gradient;
+            }
+            return Collections.singletonList(gradient.get(0));
+        }
+
+        float fPhase = 0;
+
+        float sectorLength = (float) (length - 1) / (gradient.size() - 1);
+        float factorStep = 1.0f / (sectorLength);
+
+        long index = 0;
+
+        int colorIndex = 0;
+
+        for (long i = 0; i < length; i++) {
+
+            if (factorStep * index > 1) {
+                colorIndex++;
+                index = 0;
+            }
+
+            float factor = factorStep * (index++ + fPhase);
+            // loop around if needed
+            if (factor > 1) {
+                factor = 1 - (factor - 1);
+            }
+
+            colors.add(TextColor.lerp(
+                    factor,
+                    gradient.get(colorIndex),
+                    gradient.get(Math.min(gradient.size() - 1, colorIndex + 1))
+            ));
+        }
+
+        return colors;
+    }
+
+    public enum TextControl {
+        RESET('r');
+
+        private char c;
+
+        TextControl(char c) {
+            this.c = c;
+        }
+
+        public char getChar() {
+            return c;
+        }
+    }
+
+    /**
+     * Create a click event for an action and its (string) value.
+     * <p>
+     * Adventure 5 replaced the {@link ClickEvent.Action} enum with a set of typed action classes and removed both
+     * {@code ClickEvent.Action#valueOf(String)} and {@code ClickEvent#clickEvent(Action, String)}. The action-specific
+     * factory methods used here exist - with identical descriptors - on every Adventure version, so this works on
+     * Adventure 4 (Minecraft 1.17 - 1.21.x) and Adventure 5 (Minecraft 26.2+) alike.
+     *
+     * @param action  The action to create the click event for
+     * @param value   The value of the click event
+     * @param payload Optional binary tag payload, only used by the {@code custom} action
+     * @return The created click event
+     * @throws IllegalArgumentException if the action is not supported or the value is invalid for it
+     */
+    public static ClickEvent createClickEvent(ClickEvent.Action action, String value, BinaryTagHolder payload) {
+        switch (actionName(action)) {
+            case "open_url":
+                return ClickEvent.openUrl(value);
+            case "open_file":
+                return ClickEvent.openFile(value);
+            case "run_command":
+                return ClickEvent.runCommand(value);
+            case "suggest_command":
+                return ClickEvent.suggestCommand(value);
+            case "copy_to_clipboard":
+                return ClickEvent.copyToClipboard(value);
+            case "change_page":
+                try {
+                    return ClickEvent.changePage(Integer.parseInt(value));
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException(value + " is not a valid page number!", e);
+                }
+            case "custom":
+                return createCustomClickEvent(value, payload);
+            default:
+                throw new IllegalArgumentException("Click event action " + actionName(action) + " is not supported!");
+        }
+    }
+
+    /**
+     * Create a {@code custom} click event. Requires Adventure 4.22 or newer, older versions do not know that action.
+     *
+     * @param key     The key of the custom action
+     * @param payload The binary tag payload of the action, may be null
+     * @return The created click event
+     */
+    private static ClickEvent createCustomClickEvent(String key, BinaryTagHolder payload) {
+        try {
+            return ClickEvent.custom(Key.key(key), payload != null ? payload : BinaryTagHolder.binaryTagHolder(""));
+        } catch (NoSuchMethodError | NoClassDefFoundError e) {
+            throw new IllegalArgumentException("Custom click events require Adventure 4.22 or newer!", e);
+        }
+    }
+
+    /**
+     * Get the (serialized, lower case) name of a click event action in a way that works on both Adventure 4,
+     * where actions are enum constants, and Adventure 5, where they are individual classes.
+     *
+     * @param action The action to get the name of
+     * @return The name of the action, e.g. {@code run_command}
+     */
+    public static String actionName(ClickEvent.Action action) {
+        String name = ClickEvent.Action.NAMES.key(action);
+        return (name != null ? name : action.toString()).toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Read the string value of a click event.
+     * <p>
+     * Adventure 4 exposes it via {@code ClickEvent#value()}, Adventure 4.22 added typed payloads and Adventure 5
+     * removed {@code value()} entirely. Both are read reflectively so that this class never resolves a payload type
+     * on an Adventure version that doesn't have one.
+     *
+     * @param event The click event to read the value of
+     * @return The value of the click event, or <code>null</code> if it could not be read
+     */
+    public static String clickEventValue(ClickEvent event) {
+        if (CLICK_EVENT_VALUE != null) {
+            try {
+                return (String) CLICK_EVENT_VALUE.invoke(event);
+            } catch (ReflectiveOperationException | ClassCastException ignored) {
+            }
+        }
+        final Object payload = clickEventPayload(event);
+        if (payload == null) {
+            return null;
+        }
+        Object value = invoke(payload, "value"); // ClickEvent.Payload.Text
+        if (value instanceof String) {
+            return (String) value;
+        }
+        value = invoke(payload, "integer"); // ClickEvent.Payload.Int
+        if (value != null) {
+            return String.valueOf(value);
+        }
+        value = invoke(payload, "key"); // ClickEvent.Payload.Custom
+        if (value instanceof Key) {
+            return ((Key) value).asString();
+        }
+        return null;
+    }
+
+    /**
+     * Read the binary tag payload of a {@code custom} click event
+     *
+     * @param event The click event to read the payload of
+     * @return The payload, or <code>null</code> if the event has none
+     */
+    public static BinaryTagHolder clickEventPayloadTag(ClickEvent event) {
+        final Object payload = clickEventPayload(event);
+        final Object nbt = payload != null ? invoke(payload, "nbt") : null;
+        return nbt instanceof BinaryTagHolder ? (BinaryTagHolder) nbt : null;
+    }
+
+    private static Object clickEventPayload(ClickEvent event) {
+        if (CLICK_EVENT_PAYLOAD == null) {
+            return null;
+        }
+        try {
+            return CLICK_EVENT_PAYLOAD.invoke(event);
+        } catch (ReflectiveOperationException ignored) {
+            return null;
+        }
+    }
+
+    /**
+     * Invoke a no-args method on an object, looking it up on the interfaces it implements first - the payload
+     * implementations in Adventure 5 are package private, so their methods can only be called via their interfaces.
+     *
+     * @param target The object to invoke the method on
+     * @param name   The name of the method
+     * @return The returned value, or <code>null</code> if the method doesn't exist or couldn't be invoked
+     */
+    private static Object invoke(Object target, String name) {
+        for (Class<?> type = target.getClass(); type != null; type = type.getSuperclass()) {
+            for (Class<?> parent : type.getInterfaces()) {
+                try {
+                    return parent.getMethod(name).invoke(target);
+                } catch (ReflectiveOperationException | RuntimeException ignored) {
+                }
+            }
+        }
+        try {
+            return target.getClass().getMethod(name).invoke(target);
+        } catch (ReflectiveOperationException | RuntimeException ignored) {
+            return null;
+        }
+    }
+
+    private static final java.lang.reflect.Method CLICK_EVENT_VALUE = findMethod(ClickEvent.class, "value");
+    private static final java.lang.reflect.Method CLICK_EVENT_PAYLOAD = findMethod(ClickEvent.class, "payload");
+
+    private static java.lang.reflect.Method findMethod(Class<?> clazz, String name) {
+        try {
+            return clazz.getMethod(name);
+        } catch (NoSuchMethodException | SecurityException ignored) {
+            return null;
+        }
+    }
+
+    /**
+     * Whether this Adventure version supports a certain class
+     *
+     * @param className The fully qualified name of the class to check for
+     * @return Whether the class could be found
+     */
+    static boolean hasClass(String className) {
+        try {
+            Class.forName(className, false, Util.class.getClassLoader());
+            return true;
+        } catch (Throwable ignored) {
+            return false;
+        }
+    }
+}

--- a/common/src/main/java/net/william278/huskclaims/user/CommandUser.java
+++ b/common/src/main/java/net/william278/huskclaims/user/CommandUser.java
@@ -40,7 +40,24 @@ public interface CommandUser {
     }
 
     default void sendMessage(@NotNull MineDown mineDown) {
-        this.sendMessage(mineDown.toComponent());
+        this.sendMessage(format(mineDown));
+    }
+
+    /**
+     * Format a {@link MineDown} message into a {@link Component}, falling back to the plain, un-formatted message
+     * if it couldn't be parsed - a badly formatted locale, or one using a formatting feature the server's Adventure
+     * version doesn't support, should never break the command a user is running.
+     *
+     * @param mineDown the message to format
+     * @return the formatted component
+     */
+    @NotNull
+    static Component format(@NotNull MineDown mineDown) {
+        try {
+            return mineDown.toComponent();
+        } catch (Throwable e) {
+            return Component.text(mineDown.message());
+        }
     }
 
 }

--- a/common/src/main/java/net/william278/huskclaims/user/OnlineUser.java
+++ b/common/src/main/java/net/william278/huskclaims/user/OnlineUser.java
@@ -32,6 +32,7 @@ import org.jetbrains.annotations.NotNull;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.logging.Level;
 
 /**
  * Platform-agnostic representation of an online user
@@ -72,7 +73,12 @@ public abstract class OnlineUser extends User implements OperationUser, CommandU
     }
 
     public void sendMessage(@NotNull MineDown mineDown) {
-        sendMessage(mineDown.toComponent());
+        try {
+            sendMessage(mineDown.toComponent());
+        } catch (Throwable e) {
+            plugin.log(Level.WARNING, "Failed to format a message: %s".formatted(mineDown.message()), e);
+            sendMessage(Component.text(mineDown.message()));
+        }
     }
 
     public abstract void sendPluginMessage(@NotNull String channel, byte[] message);

--- a/common/src/test/java/net/william278/huskclaims/config/MineDownFormattingTests.java
+++ b/common/src/test/java/net/william278/huskclaims/config/MineDownFormattingTests.java
@@ -1,0 +1,119 @@
+/*
+ * This file is part of HuskClaims, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package net.william278.huskclaims.config;
+
+import de.exlll.configlib.YamlConfigurations;
+import de.themoep.minedown.adventure.MineDown;
+import de.themoep.minedown.adventure.Util;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests the MineDown formatting of locales.
+ * <p>
+ * Minecraft 26.2 ships Adventure 5, which replaced the {@code ClickEvent.Action} enum with typed action classes;
+ * anything reading it as an enum (as MineDown used to) blows up with a {@link NoSuchMethodError} the moment a
+ * message with a click event is sent.
+ */
+@DisplayName("MineDown Formatting Tests")
+public class MineDownFormattingTests {
+
+    @ParameterizedTest(name = "{1} Locales")
+    @DisplayName("Test All Locales Format")
+    @MethodSource("provideLocaleFiles")
+    public void testAllLocalesFormat(@NotNull File file, @SuppressWarnings("unused") @NotNull String keyName) {
+        final Locales locales = YamlConfigurations.load(file.toPath(), Locales.class);
+        assertFalse(locales.locales.isEmpty(), "No locales were loaded from " + file.getName());
+        locales.locales.keySet().forEach(key -> assertDoesNotThrow(
+                () -> locales.getLocale(key).orElseThrow().toComponent(),
+                "Locale %s in %s could not be formatted".formatted(key, file.getName())
+        ));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @DisplayName("Test Click Event Actions")
+    @CsvSource({
+            "run_command=/huskclaims about, run_command, /huskclaims about",
+            "suggest_command=/claim 10, suggest_command, /claim 10",
+            "open_url=https://william278.net, open_url, https://william278.net",
+            "open_file=/home/server/logs/latest.log, open_file, /home/server/logs/latest.log",
+            "copy_to_clipboard=Some text, copy_to_clipboard, Some text",
+            "change_page=4, change_page, 4"
+    })
+    public void testClickEventActions(@NotNull String definition, @NotNull String action, @NotNull String value) {
+        final Component component = new MineDown("[Click me](%s)".formatted(definition)).toComponent();
+        final ClickEvent clickEvent = component.clickEvent();
+        assertNotNull(clickEvent, "No click event was created for " + definition);
+        assertEquals(action, Util.actionName(clickEvent.action()));
+        assertEquals(value, Util.clickEventValue(clickEvent));
+    }
+
+    @DisplayName("Test Command Click Event Shorthand")
+    @ParameterizedTest(name = "{0}")
+    @CsvSource({
+            "/claim, run_command, /claim",
+            "https://william278.net, open_url, https://william278.net"
+    })
+    public void testClickEventShorthand(@NotNull String definition, @NotNull String action, @NotNull String value) {
+        final Component component = new MineDown("[Click me](%s)".formatted(definition)).toComponent();
+        final ClickEvent clickEvent = component.clickEvent();
+        assertNotNull(clickEvent, "No click event was created for " + definition);
+        assertEquals(action, Util.actionName(clickEvent.action()));
+        assertEquals(value, Util.clickEventValue(clickEvent));
+    }
+
+    @DisplayName("Test Click Event Replacements")
+    @ParameterizedTest(name = "{0}")
+    @CsvSource({
+            "run_command=/group %name%, /group William",
+            "suggest_command=/untrust %name%, /untrust William"
+    })
+    public void testClickEventReplacements(@NotNull String definition, @NotNull String value) {
+        final Component component = new MineDown("[Click me](%s)".formatted(definition))
+                .replace("name", "William").toComponent();
+        final ClickEvent clickEvent = component.clickEvent();
+        assertNotNull(clickEvent, "No click event was created for " + definition);
+        assertEquals(value, Util.clickEventValue(clickEvent));
+    }
+
+    @NotNull
+    private static Stream<Arguments> provideLocaleFiles() {
+        final URL url = MineDownFormattingTests.class.getClassLoader().getResource("locales");
+        assertNotNull(url, "locales folder is missing");
+
+        return Stream.of(Objects.requireNonNull(new File(url.getPath()).listFiles(
+                file -> file.getName().endsWith("yml")
+        ))).map(file -> Arguments.of(file, file.getName().replace(".yml", "")));
+    }
+
+}

--- a/paper/src/main/java/net/william278/huskclaims/PaperHuskClaims.java
+++ b/paper/src/main/java/net/william278/huskclaims/PaperHuskClaims.java
@@ -20,18 +20,15 @@
 package net.william278.huskclaims;
 
 import lombok.NoArgsConstructor;
-import net.kyori.adventure.audience.Audience;
 import net.william278.huskclaims.highlighter.PaperBlockDisplayHighlighter;
 import net.william278.huskclaims.listener.ClaimsListener;
 import net.william278.huskclaims.listener.PaperListener;
 import net.william278.huskclaims.position.Position;
 import net.william278.huskclaims.user.BukkitUser;
 import net.william278.huskclaims.user.OnlineUser;
-import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
-import java.util.UUID;
 
 @NoArgsConstructor
 public class PaperHuskClaims extends BukkitHuskClaims {
@@ -40,13 +37,6 @@ public class PaperHuskClaims extends BukkitHuskClaims {
     @SuppressWarnings("UnstableApiUsage")
     public void sendBlockUpdates(@NotNull OnlineUser user, @NotNull Map<Position, MaterialBlock> blocks) {
         ((BukkitUser) user).getBukkitPlayer().sendMultiBlockChange(Adapter.adapt(blocks));
-    }
-
-    @Override
-    @NotNull
-    public Audience getAudience(@NotNull UUID user) {
-        final Player player = getServer().getPlayer(user);
-        return player == null || !player.isOnline() ? Audience.empty() : player;
     }
 
     @Override


### PR DESCRIPTION
Minecraft 26.2 ships Adventure 5, which replaced the `ClickEvent.Action` enum with typed action classes. MineDown 1.8.2 reads it as an enum, so any message with a click event threw:

```
java.lang.NoSuchMethodError: 'ClickEvent$Action ClickEvent$Action.valueOf(String)'
    at MineDownParser.parseEvent(MineDownParser.java:493)
```

No MineDown release supports both Adventure 4 and 5, so it's vendored (MIT, upstream Phoenix616/MineDown) under `common/src/main/java/de/themoep/minedown/adventure` and click events are built from the per-action factory methods, which exist with identical descriptors on both. Newer-only API (shadow colours, object components) is confined to `AdventureCompat` so it's never resolved on older servers — 1.17+ support is unchanged.

Also:
- Use the server's native audiences where it implements Adventure itself (Paper 1.16.5+); adventure-platform is Adventure 4 only and is now created just for legacy Spigot servers.
- Unformattable locales fall back to raw text with a logged warning instead of aborting the command.
- Compile against adventure-api 5.2.0, adventure-platform 4.4.1, plus tests for every click action and every bundled locale.

Verified by parsing all 1687 locale strings from the 7 bundled locale files on Adventure 5.2.0, 4.26.1, 4.24.0 and 4.14.0: no errors, identical component output on every version. Gradle couldn't run in my sandbox (blocked maven repos), so the full build still needs a run here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLuANNxeqgEouCab38nCNr)_