### PR TITLE
fix: don't load chunks or teleport on the calling thread on 26.2

### DIFF
--- a/bukkit/src/main/java/net/william278/huskclaims/user/BukkitUser.java
+++ b/bukkit/src/main/java/net/william278/huskclaims/user/BukkitUser.java
@@ -19,13 +19,13 @@
 
 package net.william278.huskclaims.user;
 
-import io.papermc.lib.PaperLib;
 import lombok.Getter;
 import net.william278.cloplib.listener.InspectorCallbackProvider;
 import net.william278.huskclaims.BukkitHuskClaims;
 import net.william278.huskclaims.HuskClaims;
 import net.william278.huskclaims.hook.HuskHomesHook;
 import net.william278.huskclaims.position.Position;
+import net.william278.huskclaims.util.PaperApiCompat;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -126,7 +126,7 @@ public class BukkitUser extends OnlineUser {
 
     private void teleportInstant(@NotNull Position position) {
         final Location location = BukkitHuskClaims.Adapter.adapt(position);
-        plugin.runSync(bukkitPlayer, () -> PaperLib.teleportAsync(bukkitPlayer, location));
+        plugin.runSync(bukkitPlayer, () -> PaperApiCompat.teleportAsync(bukkitPlayer, location));
     }
 
     @Override

--- a/bukkit/src/main/java/net/william278/huskclaims/util/BukkitSafeTeleportProvider.java
+++ b/bukkit/src/main/java/net/william278/huskclaims/util/BukkitSafeTeleportProvider.java
@@ -19,7 +19,6 @@
 
 package net.william278.huskclaims.util;
 
-import io.papermc.lib.PaperLib;
 import net.william278.huskclaims.BukkitHuskClaims;
 import net.william278.huskclaims.position.Position;
 import net.william278.huskclaims.position.World;
@@ -45,7 +44,7 @@ public interface BukkitSafeTeleportProvider extends SafeTeleportProvider {
     @NotNull
     default CompletableFuture<Optional<Position>> findSafePosition(@NotNull Position position) {
         final Location location = BukkitHuskClaims.Adapter.adapt(position);
-        return PaperLib.getChunkAtAsync(location).thenApply(Chunk::getChunkSnapshot).thenApply(
+        return PaperApiCompat.getChunkAtAsync(location).thenApply(Chunk::getChunkSnapshot).thenApply(
                 (chunk) -> getSafe(position.getWorld(), chunk, location.getBlockX(), location.getBlockZ())
         );
     }

--- a/bukkit/src/main/java/net/william278/huskclaims/util/PaperApiCompat.java
+++ b/bukkit/src/main/java/net/william278/huskclaims/util/PaperApiCompat.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of HuskClaims, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package net.william278.huskclaims.util;
+
+import io.papermc.lib.PaperLib;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Async chunk loading and teleportation, using the server's own API where it provides one.
+ * <p>
+ * PaperLib picks its implementations by parsing the Minecraft version out of {@link org.bukkit.Bukkit#getVersion()}
+ * with a pattern that only matches the old {@code 1.x.y} scheme. On Minecraft 26.2 that parse fails, PaperLib decides
+ * the server is ancient and falls back to loading chunks and teleporting on the calling thread - which, on Folia-based
+ * servers, trips a {@code TickThread} check and fails the command outright.
+ * <p>
+ * Looking the methods up directly means the modern paths are used whenever the server actually has them, no matter
+ * how it happens to name its version; PaperLib remains the fallback for servers that don't.
+ */
+public final class PaperApiCompat {
+
+    private static final MethodHandle GET_CHUNK_AT_ASYNC = findMethod(
+            World.class, "getChunkAtAsync", CompletableFuture.class, int.class, int.class
+    );
+    private static final MethodHandle TELEPORT_ASYNC = findMethod(
+            Entity.class, "teleportAsync", CompletableFuture.class, Location.class
+    );
+
+    private PaperApiCompat() {
+    }
+
+    /**
+     * Load the chunk at a location, off the main thread where the server supports it.
+     * <p>
+     * The returned future is completed on the thread that owns the chunk, so it is safe to touch the chunk in a
+     * callback chained onto it.
+     *
+     * @param location the location to load the chunk at
+     * @return a future that completes with the loaded chunk
+     */
+    @NotNull
+    @SuppressWarnings("unchecked")
+    public static CompletableFuture<Chunk> getChunkAtAsync(@NotNull Location location) {
+        final World world = location.getWorld();
+        if (GET_CHUNK_AT_ASYNC == null || world == null) {
+            return PaperLib.getChunkAtAsync(location);
+        }
+        try {
+            return (CompletableFuture<Chunk>) GET_CHUNK_AT_ASYNC.invoke(
+                    world, location.getBlockX() >> 4, location.getBlockZ() >> 4
+            );
+        } catch (Throwable e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    /**
+     * Teleport an entity, asynchronously where the server supports it.
+     * <p>
+     * Must be called from the thread that owns the entity; on Folia-based servers a plain teleport cannot move an
+     * entity between regions, so the async API is the only way to do this.
+     *
+     * @param entity   the entity to teleport
+     * @param location where to teleport it to
+     */
+    public static void teleportAsync(@NotNull Entity entity, @NotNull Location location) {
+        if (TELEPORT_ASYNC == null) {
+            PaperLib.teleportAsync(entity, location);
+            return;
+        }
+        try {
+            final Object ignored = TELEPORT_ASYNC.invoke(entity, location);
+        } catch (Throwable e) {
+            throw new IllegalStateException("Failed to teleport %s".formatted(entity.getName()), e);
+        }
+    }
+
+    private static MethodHandle findMethod(@NotNull Class<?> owner, @NotNull String name,
+                                           @NotNull Class<?> returnType, @NotNull Class<?>... parameters) {
+        try {
+            return MethodHandles.publicLookup().findVirtual(owner, name, MethodType.methodType(returnType, parameters));
+        } catch (NoSuchMethodException | IllegalAccessException | RuntimeException ignored) {
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
PaperLib picks its async chunk/teleport implementations by regex-parsing the Minecraft version out of `Bukkit.getVersion()` — the pattern only matches the old `1.x.y` scheme. On 26.2 the parse fails, so PaperLib assumes a pre-1.13 server and falls back to loading chunks and teleporting on the calling thread. On Folia-based servers (Canvas) that trips a TickThread check and fails the command:

```
Thread failed main thread check: Async chunk retrieval
    at CraftWorld.getChunkAt(CraftWorld.java:373)
    at io.papermc.lib.features.asyncchunks.AsyncChunksSync.getChunkAtAsync
    at BukkitSafeTeleportProvider.findSafePosition(BukkitSafeTeleportProvider.java:48)
    at TrappedCommand.execute(TrappedCommand.java:53)
```

`PaperApiCompat` looks `World#getChunkAtAsync` and `Entity#teleportAsync` up directly, so the modern paths are used whenever the server has them regardless of how it names its version; PaperLib stays as the fallback for servers that don't. `getChunkAtAsync` is safe to call from any thread and completes on the thread owning the chunk.

Teleporting was silently broken the same way — PaperLib was falling back to a plain `entity.teleport()`, which on Folia can't move an entity between regions, so `/trapped` would have failed at the teleport too. Both call sites now go through the async APIs.

Verified against stubbed Bukkit interfaces: with the modern methods present they're used with the right chunk coords and no sync chunk load happens; with them absent it falls back to PaperLib cleanly. Gradle couldn't run in my sandbox (blocked maven repos), so the full build still needs a run here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLuANNxeqgEouCab38nCNr)_